### PR TITLE
boosts Head based moves

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -7712,12 +7712,12 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onModifyAtkPriority: 5,
 		onModifyAtk(atk) {
 			if (this.field.getPseudoWeather('inverseroom')) {
-				return this.chainModify(2);
+				return this.chainModify(1.5);
 			}
 		},
 		onModifySpe(spe, pokemon) {
 			if (this.field.getPseudoWeather('inverseroom')) {
-				return this.chainModify(2);
+				return this.chainModify(1.5);
 			}
 		},
 		name: "Flip Flops",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -27796,7 +27796,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Sly Squall",
 		pp: 15,
 		priority: 0,
-		flags: {protect: 1, mirror: 1},
+		flags: {protect: 1, mirror: 1, wind: 1},
 		beforeMoveCallback(source, target, move) {
 			if (source.illusion) move.willCrit = true;
 		},
@@ -27839,7 +27839,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				this.add('-sidestart', targetSide, 'swamp');
 			},
 			onModifySpe(spe, pokemon) {
-				return this.chainModify(0.25);
+				return this.chainModify(0.8);
 			},
 			onSideResidualOrder: 26,
 			onSideResidualSubOrder: 9,
@@ -27880,12 +27880,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 	foolsgambit: {
 		num: 485,
 		accuracy: 100,
-		basePower: 135,
+		basePower: 115,
 		category: "Physical",
 		name: "Fool's Gambit",
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
+		recoil: [33, 100],
 		target: "allAdjacent",
 		type: "Dark",
 		isNonstandard: "Future",

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -2439,7 +2439,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	beamboost: {
 		name: "Beam Boost",
 		desc: "This Pokemon's Beam-based attacks have their power multiplied by 1.5.",
-		shortDesc: "This Pokemon's beam attacks have 1.5x power",
+		shortDesc: "This Pokemon's beam attacks have 1.5x power.",
 	},
 	bigbrain: {
 		name: "Big Brain",
@@ -2624,7 +2624,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	asonehorse: {
 		name: "As One (Horse)",
-		shortDesc: "The combination of Grim Neight, Chilling Neigh, and Striker",
+		shortDesc: "The combination of Grim Neigh, Chilling Neigh, and Striker.",
 
 		start: "  [POKEMON] is ready to yeehaw!",
 	},
@@ -2634,7 +2634,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	flipflops: {
 		name: "Flip Flops",
-		shortDesc: "Doubles Attack and Speed under Inverse Room.",
+		shortDesc: "1.5x Attack and Speed under Inverse Room.",
 	},
 	memepower: {
 		name: "Meme Power",
@@ -2740,7 +2740,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	triforce: {
 		name: "Triforce",
-		shortDesc: "In 3 turns, this Pokemon collects the Triforce, boosting Atk, SpA, and SpD.",
+		shortDesc: "In 3 turns, this Pokemon collects the Triforce, boosting Atk, Sp. Atk, and Sp. Def.",
 	},
 	infection: {
 		name: "Infection",
@@ -2760,9 +2760,9 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	eyeofblobbos: {
 		name: "Eye of Blobbos",
-		shortDesc: "If Blobbos-Eye, at end of turn changes to Eye-Mouth mode if > 1/2 max HP",
+		shortDesc: "If Blobbos-Eye, at end of the turn, changes to Eye-Mouth mode if below full HP.",
 
-		transform: "You feel a chill down your spine!",
+		transform: "You feel an evil presence watching you!",
 		transformEnd: "Blobbos-Eye-Mouth has calmed down!",
 	},
 	reconstruct: {
@@ -2771,7 +2771,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	ultraego: {
 		name: "Ultra Ego",
-		shortDesc: "Boosts Attack by 1 whenever this mon takes damage from any source.",
+		shortDesc: "Boosts Attack by 1 whenever this Pokemon takes damage from any source.",
 	},
 	limblauncher: {
 		name: "Limb Launcher",
@@ -2840,14 +2840,14 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	supermentum: {
 		name: "Supermentum",
-		shortDesc: "Switches out after using moves.",
+		shortDesc: "Switches out after using a move.",
 	},
 	muhmentum: {
 		name: "Muhmentum",
 		shortDesc: "Switches out after using offensive moves.",
 	},
 	terraform: {
-		name: "Terrform",
+		name: "Terraform",
 		desc: "Changes terrain when using certain moves relating to terrain.",
 		shortDesc: "Changes terrain to benefit certain moves.",
 	},
@@ -2911,6 +2911,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	legendary: {
 		name: "Legendary",
 		desc: "This Pokemon cannot be statused. Prevents this Pokemon's stat stages from lowering. The power of this Pokemon's move is multiplied by 1.5 against Dark- and Dragon-types. Heroic Strike becomes Heroic Onslaught.",
+		shortDesc: "Cannot be statused, Clear Body, x1.5 damage vs Dark/Dragon, Heroic Strike -> Heroic Onslaught.",
 	},
 	copypower: {
 		name: "Copy Power",
@@ -2926,7 +2927,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	inmemoriam: {
 		name: "In Memoriam",
-		shortDesc: "Magic Guard + Flare Heal + Fire+Steel Immunity.",
+		shortDesc: "Magic Guard, Flare Heal, immune to Fire and Steel.",
 
 		start: "  [POKEMON] is always ready to rember ;_;7",
 	},
@@ -2937,7 +2938,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	boardpoweryou: {
 		name: "Board Power (/you/)",
-		shortDesc: "Every Board Power combined except /Z/ and Gorilla Tactics.",
+		shortDesc: "Every Board Power combined except /z/ and Gorilla Tactics.",
 	},
 	capacitance: {
 		name: "Capacitance",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -8563,7 +8563,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	foolsgambit: {
 		name: "Fool's Gambit",
-		shortDesc: "No additional effect.",
+		shortDesc: "Has 33% recoil.",
 	},
 	trapcard: {
 		name: "Trap Card",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -7761,7 +7761,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	soulcrusher: {
 		name: "Soul Crusher",
 		desc: "Power is multiplied by 999 times if the target has less than or equal to half of its maximum HP remaining. Heals for 100% of the damage the move has dealt.",
-		shortDesc: "999x power if target HP <50%, heals for damage dealt.",
+		shortDesc: "999x power if target HP < 50%, heals for damage dealt.",
 	},
 	tombstoner: {
 		name: "Tombstoner",
@@ -7771,7 +7771,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	fruitjuice: {
 		name: "Fruit Juice",
 		desc: "Power is equal to 120 times the user's Stockpile count. Whether or not this move is successful, the user's Defense and Special Defense decrease by as many stages as Stockpile had increased them, and the user's Stockpile count resets to 0. Lowers the target's Sp.Def by two stages.",
-		shortDesc: "Gets stronger with Stockpile, -2 SpD to the target",
+		shortDesc: "Gets stronger with Stockpile, -2 Sp. Def to the target.",
 	},
 	phantomfang: {
 		name: "Phantom Fang",
@@ -7802,7 +7802,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	brutalpunishment: {
 		name: "Brutal Punishment",
 		desc: "Has a 100% chance to raise the user's Attack and Special Attack by 1 stage. If the user is a Disbeary in Nice Mode, this move is Fairy type. If the user is a Disbeary in Ebil Mode, this move is Dark type. This move cannot be used successfully unless the user's current form, while considering Transform, is Nice or Ebil Mode Disbeary.",
-		shortDesc: "Disbeary: Fairy; Ebil: Dark; 100% +1 Atk and SpA.",
+		shortDesc: "Disbeary: Fairy; Ebil: Dark; 100% +1 Atk and Sp. Atk.",
 	},
 	shinestrike: {
 		name: "Shine Strike",
@@ -7825,7 +7825,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	starseedblast: {
 		name: "Starseed Blast",
 		desc: "Hits two to five times. Has a 35% chance to hit two or three times and a 15% chance to hit four or five times. If one of the hits breaks the target's substitute, it will take damage for the remaining hits. If the user has the Skill Link Ability, this move will always hit five times.",
-		shortDesc: "Hits 2-5 times, Special if Sp. Atk > Atk",
+		shortDesc: "Hits 2-5 times, Special if Sp. Atk > Atk.",
 	},
 	brandingblade: {
 		name: "Flare Blitz",
@@ -8034,7 +8034,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	matingpress: {
 		name: "Mating Press",
 		desc: "20% chance to have a child with the opposing mon with no item and only Metronome. Can only occur once for a user.",
-		shortDesc: "Produces a child. Uses Defense",
+		shortDesc: "Produces a child. Uses Defense.",
 
 		activate: "  [SOURCE] had a child with [POKEMON]!",
 		fail: "[POKEMON] had a miscarriage...",
@@ -8186,7 +8186,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	rainbowbeam: {
 		name: "Rainbow Beam",
-		shortDesc: "Adds all types into one attack.",
+		shortDesc: "Adds all types into one attack. Taste the rainbow, motherfucker!",
 	},
 	freikugel: {
 		name: "Freikugel",
@@ -8262,7 +8262,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	heavensblessing: {
 		name: "Heaven's Blessing",
-		shortDesc: "Heals self and activates Wish effect.",
+		shortDesc: "Heals user by 25% of max HP, activates Wish effect.",
 	},
 	heavenpierce: {
 		name: "Heaven Pierce",
@@ -8501,7 +8501,7 @@ export const MovesText: {[k: string]: MoveText} = {
 			desc: "The power of this move varies. 5% chances for 10 and 150 power, 10% chances for 30 and 110 power, 20% chances for 50 and 90 power, and 30% chance for 70 power. Power doubles if the target is using Thunder Drop.",
 		},
 
-		activate: "  Quality Rip [NUMBER]!",
+		activate: "  Rip Quality: [NUMBER]!",
 	},
 	concussion: {
 		name: "Concussion",
@@ -8541,7 +8541,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	swamp: {
 		name: "Swamp",
-		shortDesc: "For 4 turns, foes' Speed is quartered.",
+		shortDesc: "For 4 turns, foes' Speed is reduced by 20%.",
 		start: "  A swamp enveloped [TEAM]!",
 		end: "  The swamp around [TEAM] disappeared!",
 	},
@@ -8575,11 +8575,12 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	heroicstrike: {
 		name: "Heroic Strike",
-		shortDesc: "Ignores immunities. Uses Fighting-type effectiveness if it would be SE. Cannot miss. Special if user's Sp. Atk > Atk. Ignores the target's stat stage changes.",
+		desc: "Ignores immunities. Uses Fighting-type effectiveness if it would be SE. Cannot miss. Special if user's Sp. Atk > Atk. Ignores the target's stat stage changes.",
+		shortDesc: "Ignores immunities. Fighting if it would be SE. Special if user's Sp. Atk > Atk. Ignores target's stat changes.",
 	},
 	heroiconslaught: {
 		name: "Heroic Onslaught",
-		shortDesc: "Hits twice. Ignores immunities. Cannot miss. Special if user's Sp. Atk > Atk. Ignores the target's stat stage changes.",
+		shortDesc: "Hits twice. Ignores immunities. Cannot miss. Special if user's Sp. Atk > Atk. Ignores target's stat changes.",
 	},
 	drinkpotion: {
 		name: "Drink Potion",
@@ -8631,7 +8632,7 @@ export const MovesText: {[k: string]: MoveText} = {
 	},
 	deepfreeze: {
 		name: "Deep Freeze",
-		shortDesc: "Freezes the target and self. Fails if self already has a status condition.",
+		shortDesc: "Freezes the target and user. Fails if user already has a status condition.",
 	},
 	sap: {
 		name: "Sap",


### PR DESCRIPTION
## Description
A bunch of CAB stuff alongside general additions of periods to move descriptions that didn't have them.
Also the learnsets thing is like that because I hate VSCODE and just uploaded the changed file from my computer.

## Checklist
- [V] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [V] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [V] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities