### PR TITLE
[CAP] Major fix for legality

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -8616,6 +8616,162 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		tier: "Illegal",
 		isNonstandard: "Future",
 	},
+	saccestoda: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	seaman: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	barabyss: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	flubbster: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	blubbastard: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	mogumole: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	polybrawn: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	polybrawnh: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	polybrawnw: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	polybrawni: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	polybrawnp: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	polybrawnk: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	knitten: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	voltocor: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	volbrat: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	moblin: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	fangster: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	whimple: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	whipscuffle: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	pascal: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	moltama: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	juankey: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	mimikrab: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	ramboom: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	vinedup: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	afloof: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	burnugget: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	cheepouf: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	doomter: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	fleurrium: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	garookie: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	garble: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	nebulite: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+		},
+	primitool: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	shroomag: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	skubmarine: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	skubmarineanti: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	triderling: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	turtini: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
 	doomsday: {
 		tier: "Illegal",
 		isNonstandard: "Future",

--- a/data/mods/clovercap/formats-data.ts
+++ b/data/mods/clovercap/formats-data.ts
@@ -206,7 +206,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	mimikrab: {
 		inherit: true,
 		isNonstandard: null,
-		tier: "OU",
+		tier: "LC",
 	},
 	ankhira: {
 		inherit: true,
@@ -541,7 +541,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	voltocor: {
 		inherit: true,
 		isNonstandard: null,
-		tier: "OU",
+		tier: "LC",
 	},
 	wycern: {
 		inherit: true,
@@ -681,7 +681,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	juankey: {
 		inherit: true,
 		isNonstandard: null,
-		tier: "OU",
+		tier: "LC",
 	},
 	tarquail: {
 		inherit: true,

--- a/data/mods/sandbox/formats-data.ts
+++ b/data/mods/sandbox/formats-data.ts
@@ -10503,6 +10503,31 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		tier: "OU",
 		isNonstandard: null,
 	},
+	barabyss: {
+		inherit: true,
+		tier: "OU",
+		isNonstandard: null,
+	},
+	seaman: {
+		inherit: true,
+		tier: "OU",
+		isNonstandard: null,
+	},
+	saccestoda: {
+		inherit: true,
+		tier: "OU",
+		isNonstandard: null,
+	},
+	flubbster: {
+		inherit: true,
+		tier: "OU",
+		isNonstandard: null,
+	},
+	blubbastard: {
+		inherit: true,
+		tier: "OU",
+		isNonstandard: null,
+	},
 	autumn: {
 		inherit: true,
 		tier: "OU",

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -36464,7 +36464,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 	moltama: {
 	   num: 8132,
 	   name: "Moltama",
-	   types: ["Ground"],
+	   types: ["Fire"],
 	   genderRatio: {M: 0.5, F: 0.5},
 	   baseStats: {hp: 55, atk: 35, def: 88, spa: 60, spd: 34, spe: 10},
 	   abilities: {0: "Battle Armor", 1: "Magma Armor", H: "Turboblaze", S: "Sheer Force"},


### PR DESCRIPTION
Fixing some Typos,removes the sandbox mons from CAP

Checklist
- [Done] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [Done ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ Done] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities
