### PR TITLE
[CAP][SANDBOX] misc changes

### DIFF
--- a/data/mods/sandbox/formats-data.ts
+++ b/data/mods/sandbox/formats-data.ts
@@ -10638,6 +10638,11 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		tier: "OU",
 		isNonstandard: null,
 	},
+	krakenwalker: {
+		inherit: true,
+		tier: "OU",
+		isNonstandard: null,
+	},
 	susko: {
 		inherit: true,
 		tier: "OU",

--- a/data/mods/sandbox/moves.ts
+++ b/data/mods/sandbox/moves.ts
@@ -4303,6 +4303,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	krackocean: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	susteelstrike: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -41769,7 +41769,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		types: ["Poison", "Electric"],
 		gender: "N",
 		baseStats: {hp: 130, atk: 86, def: 70, spa: 70, spd: 130, spe: 70},
-		abilities: {0: "Download"},
+		abilities: {0: "Download", H:"Serene Grace"},
 		heightm: 0.5,
 		weightkg: 6.4,
 		color: "Brown",


### PR DESCRIPTION
Actually gives the new moves to more mons,legalizes krackocean and krakenwalker in sandbox,expands dalledle and krakenwalker movepools

## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities