### PR TITLE
i was told to do this

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -433,9 +433,9 @@ export const Formats: FormatList = [
 		ruleset: ['Terastal Clause', 'Sketch Post-Gen 7 Moves', 'Obtainable', '!Obtainable Abilities', 'Species Clause', 'Nickname Clause', 'Ability Clause = 2', 'OHKO Clause', 'Evasion Moves Clause', 'Team Preview', 'HP Percentage Mod', 'Cancel Mod', 'Dynamax Clause', 'Sleep Clause Mod', 'Endless Battle Clause'],
 		banlist: [
 			'Uber', 'Niterpent',
-			'Arena Trap', 'Comatose', 'Contrary', 'Fluffy', 'Fur Coat', 'Gorilla Tactics', 'Huge Power', 'Ice Scales', 'Illusion', 'Imposter', 'Innards Out', 'Intrepid Sword',
-			'Libero', 'Moody', 'Neutralizing Gas', 'Parental Bond', 'Poison Heal', 'Power Construct', 'Protean', 'Pure Power', 'Shadow Tag', 'Simple', 'Stakeout', 'Speed Boost',
-			'Flare Heal', 'Suddenly',
+			'Arena Trap', 'Comatose', 'Contrary', 'Fluffy', 'Fuk U', 'Fur Coat', 'Gorilla Tactics', 'Huge Power', 'Ice Scales', 'Illusion', 'Imposter', 'Innards Out', 'Intrepid Sword',
+			'Libero', 'Moody', 'Neutralizing Gas', 'Parental Bond', 'Poison Heal', 'Power Construct', 'Protean', 'Pure Power', 'Shadow Tag', 'Simple', 'Stakeout', 'Stink Bomb',
+			'Speed Boost', 'Flare Heal', 'Suddenly',
 			'Water Bubble', 'Wonder Guard', 'Baton Pass',
 		],
 	},

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -8719,6 +8719,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (move.typeChangerBoosted === this.effect) return this.chainModify([4915, 4096]);
 		},
 		name: "Masterbait",
+		isNonstandard: "Future",
 		rating: 4,
 		num: 182,
 	},
@@ -8862,6 +8863,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				}
 			}
 		},
+		isNonstandard: "Future",
 		name: "Bejeweled",
 		rating: 4,
 		num: 227,
@@ -8908,6 +8910,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Woodchipper",
 		rating: 2.5,
 		num: 160,
+		isNonstandard: "Future",
 	},
 	revvingmalice: {
 		name: "Revving Malice",
@@ -10344,6 +10347,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 		name: "Power of YEEHAW!",
+		isNonstandard: "Future",
 		rating: 3,
 		num: 265,
 	},
@@ -10403,6 +10407,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		name: "Doomed",
 		rating: 6,
 		num: 666,
+		isNonstandard: "Future",
 	},
 	hyperspeen: {
 		onBasePowerPriority: 8,


### PR DESCRIPTION
## Description
Bans non-Clover abilities in AAA.
Bans Stink Bomb and Fuk U in AAA.

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities