### PR TITLE
Alternative to just deleting Plastic Surge

### DIFF
--- a/data/mods/sandbox/abilities.ts
+++ b/data/mods/sandbox/abilities.ts
@@ -1636,7 +1636,11 @@ export const Abilities: { [k: string]: ModdedAbilityData } = {
 		isNonstandard: null,
 	},
 	plasticsurge: {
-		inherit: true,
+		onStart(source) {
+			this.hint("Wack is a bad game and you should feel bad.");
+		},
+		name: "Plastic Surge",
+		rating: 4,
 		isNonstandard: null,
 	},
 	thatscap: {

--- a/data/mods/sandbox/moves.ts
+++ b/data/mods/sandbox/moves.ts
@@ -4197,6 +4197,12 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 	},
 	plasticterrain: {
 		inherit: true,
+		onTry(source) {
+			this.attrLastMove('[still]');
+			this.add('-fail', source, 'move: Plastic Terrain');
+			this.hint("Wack is a bad game and you should feel bad.");
+			return null;
+		},
 		isNonstandard: null,
 	},
 	highjumpsaw: {


### PR DESCRIPTION
## Description
Disables Plastic Surge in Sandbox. Instantly getting +4 with Own Tempo Funnedong is, unsurprisingly, not fun.

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities