### PR TITLE
fixes Fae/Terra Dozer legalization in CAB

### DIFF
--- a/data/mods/cloverblobboscap/moves.ts
+++ b/data/mods/cloverblobboscap/moves.ts
@@ -19,7 +19,7 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	faedozer: {
+	terradozer: {
 		inherit: true,
 		isNonstandard: null,
 	},


### PR DESCRIPTION
## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities