### PR TITLE
Fixed Wack abilities, status immunity, updated weathers and formats

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -906,17 +906,6 @@ export const Formats: FormatList = [
 		column: 4,
 	},
 	{
-		name: '[Gen 8 Wack Only] Anything Goes',
-		mod: 'wack',
-		ruleset: [
-			'Terastal Clause',
-			'Obtainable',
-			'Dynamax Clause',
-			'Sketch Post-Gen 7 Moves',
-			'Team Preview',
-		],
-	},
-	{
 		name: '[Gen 8 Wack Only] OU',
 		mod: 'wack',
 		ruleset: [
@@ -926,7 +915,22 @@ export const Formats: FormatList = [
 			'Sketch Post-Gen 7 Moves',
 		],
 		banlist: [
-			'Uber'
+			'Uber', 'Arena Trap', 'Moody', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
+			'Angel Powder + Substitute + Protect'
+		],
+	},
+	{
+		name: '[Gen 8 Wack Only] Ubers',
+		mod: 'wack',
+		ruleset: [
+			'Terastal Clause',
+			'Standard',
+			'Dynamax Clause',
+			'Sketch Post-Gen 7 Moves',
+		],
+		banlist: [
+			'Arena Trap', 'Moody', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
+			'Angel Powder + Substitute + Protect'
 		],
 	},
 	{
@@ -939,6 +943,10 @@ export const Formats: FormatList = [
 			'Dynamax Clause',
 			'Sketch Post-Gen 7 Moves',
 		],
+		banlist: [
+			'Arena Trap', 'Moody', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
+			'Angel Powder + Substitute + Protect'
+		],
 	},
 	{
 		name: '[Gen 8 Wack Only] LC',
@@ -949,6 +957,21 @@ export const Formats: FormatList = [
 			'Standard',
 			'Dynamax Clause',
 			'Sketch Post-Gen 7 Moves',
+		],
+		banlist: [
+			'Arena Trap', 'Moody', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
+			'Angel Powder + Substitute + Protect'
+		],
+	},
+	{
+		name: '[Gen 8 Wack Only] Anything Goes',
+		mod: 'wack',
+		ruleset: [
+			'Terastal Clause',
+			'Obtainable',
+			'Dynamax Clause',
+			'Sketch Post-Gen 7 Moves',
+			'Team Preview',
 		],
 	},
 ];

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -11269,8 +11269,10 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		isNonstandard: "Future",
 	},
 	pounce: {
-		onModifyPriority(priority, pokemon, target, move) {
-			if (!(pokemon.activeMoveActions > 1)) return priority + 1;
+		onModifyPriority(priority, source, target, move) {
+			if (source.activeMoveActions <= 1) {
+				return priority + 1;
+			}
 		},
 		name: "Pounce",
 		rating: 3,
@@ -11280,6 +11282,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	vespertine: {
 		onModifySpe(spe, pokemon) {
 			if (this.field.isWeather('midnight')) return this.chainModify(2);
+			if (this.field.isWeather(['sunnyday', 'desolateland'])) return this.chainModify(0.5);
 		},
 		name: "Vespertine",
 		rating: 3,
@@ -11736,9 +11739,10 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		isNonstandard: "Future",
 	},
 	graze: {
-		onDamagePriority: 1,
-		onDamage(damage, target, source, effect) {
-			this.heal(target.baseMaxhp / 16);
+		onResidualOrder: 4,
+		onResidualSubOrder: 3,
+		onResidual(pokemon) {
+			this.heal(pokemon.baseMaxhp / 16);
 		},
 		name: "Graze",
 		rating: 3,

--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -675,7 +675,6 @@ export const Aliases: {[alias: string]: string} = {
 	aboma: "Abomasnow",
 	aegi: "Aegislash",
 	aegiblade: "Aegislash-Blade",
-	aegis: "Aegislash",
 	aero: "Aerodactyl",
 	amph: "Ampharos",
 	arc: "Arceus",

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -751,7 +751,6 @@ export const Conditions: {[k: string]: ConditionData} = {
 			}
 		},
 		onWeatherModifyDamage(damage, attacker, defender, move) {
-			if (defender.hasItem('utilityumbrella')) return;
 			if (move.type === 'Ghost' || move.type === 'Fear' || move.type === 'Dark') {
 				this.debug('Midnight boost');
 				return this.chainModify(1.5);
@@ -789,7 +788,6 @@ export const Conditions: {[k: string]: ConditionData} = {
 			return 5;
 		},
 		onWeatherModifyDamage(damage, attacker, defender, move) {
-			if (defender.hasItem('utilityumbrella')) return;
 			if (move.type === 'Poison') {
 				this.debug('Acid Rain poison boost');
 				return this.chainModify(1.5);
@@ -811,6 +809,36 @@ export const Conditions: {[k: string]: ConditionData} = {
 		onFieldResidual() {
 			this.add('-weather', 'Acid Rain', '[upkeep]');
 			if (this.field.isWeather('acidrain')) this.eachEvent('Weather');
+		},
+		onWeather(target) {
+			this.damage(target.baseMaxhp / 16);
+		},
+		onFieldEnd() {
+			this.add('-weather', 'none');
+		},
+	},
+	bladerain: {
+		name: 'Blade Rain',
+		effectType: 'Weather',
+		duration: 5,
+		durationCallback(source, effect) {
+			if (source?.hasItem('chromerock')) {
+				return 8;
+			}
+			return 5;
+		},
+		onFieldStart(field, source, effect) {
+			if (effect?.effectType === 'Ability') {
+				if (this.gen <= 5) this.effectState.duration = 0;
+				this.add('-weather', 'Blade Rain', '[from] ability: ' + effect.name, '[of] ' + source);
+			} else {
+				this.add('-weather', 'Blade Rain');
+			}
+		},
+		onFieldResidualOrder: 1,
+		onFieldResidual() {
+			this.add('-weather', 'Blade Rain', '[upkeep]');
+			if (this.field.isWeather('bladerain')) this.eachEvent('Weather');
 		},
 		onWeather(target) {
 			this.damage(target.baseMaxhp / 16);

--- a/data/mods/wack/abilities.ts
+++ b/data/mods/wack/abilities.ts
@@ -1,4 +1,86 @@
 export const Abilities: {[k: string]: ModdedAbilityData} = {
+	/* Modified vanilla abilities */
+	toxicboost: {
+		inherit: true,
+		onBasePowerPriority: 19,
+		onBasePower(basePower, attacker, defender, move) {
+			if (this.field.isWeather(['acidrain'])) {
+				return this.chainModify(1.5);
+			} else if (((attacker.status === 'psn' || attacker.status === 'tox') && move.category === 'Physical')) {
+				return this.chainModify(1.5);
+			}
+		},
+		desc: "While this Pokemon is poisoned, the power of its physical attacks is multiplied by 1.5.",
+		shortDesc: "1.5x atk/spa during Acid Rain, 1.5x atk if poisoned",
+		isNonstandard: null,
+	},
+	raindish: {
+		inherit: true,
+		onWeather(target, source, effect) {
+			if (effect.id === 'acidrain' && !target.hasType('Poison')) {
+				this.damage(target.baseMaxhp / 16, target, target);
+			}
+			if (target.hasItem('utilityumbrella')) return;
+			if (effect.id === 'raindance' || effect.id === 'primordialsea') {
+				this.heal(target.baseMaxhp / 16);
+			}
+		},
+		desc: "If Rain Dance is active, this Pokemon restores 1/16 of its maximum HP, rounded down. If Acid Rain is active and the Pokemon doesn't have the Poison type, it takes 1/16 of its maximum HP, rounded down, at the end of each turn. The Rain Dance effect is prevented if this Pokemon is holding a Utility Umbrella.",
+		shortDesc: "Rain Dance: heals 1/16, Acid Rain: takes 1/16.",
+		isNonstandard: null,
+	},
+	poisonheal: {
+		inherit: true,
+		onWeather(target, source, effect) {
+			if (effect.id === 'acidrain') this.heal(target.baseMaxhp / 14);
+		},
+		onImmunity(type, pokemon) {
+			if (type === 'acidrain') return false;
+		},
+		desc: "If this Pokemon is poisoned, it restores 1/8 of its maximum HP, rounded down, at the end of each turn instead of losing HP. Also heals 1/14 of its maximum HP on Acid Rain.",
+		shortDesc: "Heals 1/8 if psn and 1/14 if Acid Rain.",
+		isNonstandard: null,
+	},
+	immunity: {
+		inherit: true,
+		onImmunity(type, pokemon) {
+			if (type === 'acidrain') return false;
+		},
+		shortDesc: "Can't be psn and cures it. Immune to Acid Rain.",
+		isNonstandard: null,
+	},
+	overcoat: {
+		inherit: true,
+		onImmunity(type, pokemon) {
+			if (type === 'sandstorm' || type === 'hail' || type === 'acidrain' || type === 'bladerain' || type === 'hyperboreanarctic' || type === 'powder') return false;
+		},
+		desc: "This Pokemon is immune to powder moves, damage from Sandstorm, Hail, Acid Rain or Blade Rain, and the effects of Rage Powder and the Effect Spore Ability.",
+		shortDesc: "Immune to powder moves, Sandstorm, Hail, Acid Rain and Blade Rain damage, Effect Spore.",
+		isNonstandard: null,
+	},
+	chlorophyll: {
+		inherit: true,
+		onModifySpe(spe, pokemon) {
+			if (['sunnyday', 'desolateland'].includes(pokemon.effectiveWeather())) {
+				return this.chainModify(2);
+			} else if (this.field.isWeather('midnight')) {
+				return this.chainModify(0.5);
+			}
+		},
+		desc: "If Sunny Day is active, this Pokemon's Speed is doubled, this effect is prevented if this Pokemon is holding a Utility Umbrella. If Midnight is active, this Pokemon's Speed is halved.",
+		shortDesc: "Sunny Day: spd doubled. Midnight: spd halved.",
+		isNonstandard: null,
+	},
+	heavymetal: {
+		inherit: true,
+		onImmunity(type, pokemon) {
+			if (type === 'bladerain') return false;
+		},
+		desc: "This Pokemon's weight is doubled. This effect is calculated after the effect of Autotomize, and before the effect of Float Stone. It's immune to Blade Rain.",
+		shortDesc: "Weight doubled. Immune to Blade Rain.",
+		isNonstandard: null,
+	},
+	/* Wack abilities */
 	darklife: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/wack/formats-data.ts
+++ b/data/mods/wack/formats-data.ts
@@ -9317,7 +9317,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	majin: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	redmist: {
@@ -10127,32 +10127,32 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	leftarm: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	rightarm: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	rightleg: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	leftleg: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	mooncore: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	lunarhead: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	nymphad: {
@@ -10187,7 +10187,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	lunarguardian: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	stalig: {
@@ -10287,7 +10287,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	perfectzygarde: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	dogzygarde: {
@@ -11827,7 +11827,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	fuidic1: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	mechamew2: {
@@ -13507,7 +13507,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	corruptedsol: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	isthis: {
@@ -14902,7 +14902,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himster: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	blasphlute: {
@@ -15042,7 +15042,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	azathoth: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	firepire: {
@@ -15077,7 +15077,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himw: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	gothot: {
@@ -15107,7 +15107,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himg: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	chanaroy: {
@@ -15477,7 +15477,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himf: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	xmrapidash: {
@@ -15632,7 +15632,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himstm: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	protogil: {
@@ -15922,12 +15922,12 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himmagma: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himwood: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	trpsychic: {
@@ -16487,7 +16487,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himrock: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	turlucky: {
@@ -16602,7 +16602,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himpaper: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	wargreymon: {
@@ -16637,7 +16637,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himmagic: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	standoge: {
@@ -17022,7 +17022,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himice: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	necroseel: {
@@ -17047,7 +17047,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himnuclear: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	amiibobowser: {
@@ -17407,7 +17407,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himfighting: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	rpmolbot: {
@@ -17512,7 +17512,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himcyber: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	garticuno: {
@@ -17747,7 +17747,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himwind: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	wdgolem: {
@@ -18012,7 +18012,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himvirus: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	samcurry: {
@@ -18157,7 +18157,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himtech: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	tfkochia: {
@@ -18217,7 +18217,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himghost: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	selizidol: {
@@ -18352,7 +18352,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himcosmic: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	whoppip: {
@@ -18372,17 +18372,17 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himground: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himfood: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himzombie: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	aukomala: {
@@ -18507,7 +18507,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himdragon: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	ellenhu: {
@@ -18707,12 +18707,12 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himchaos: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himdivine: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	ngrimer: {
@@ -18782,32 +18782,32 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	truehim: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himless: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himwall: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himanne: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himzaydolf: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	himvoid: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	fhorsea: {
@@ -18852,7 +18852,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himplastic: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	solahog: {
@@ -19517,7 +19517,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himpoison: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	mervamon: {
@@ -20912,7 +20912,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	himfear: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	coalgate: {
@@ -23267,7 +23267,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	regiweather: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	asrieldrem: {
@@ -23477,7 +23477,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	pkmnwack: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	barceus: {
@@ -27097,7 +27097,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	god: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 };

--- a/data/mods/wack/items.ts
+++ b/data/mods/wack/items.ts
@@ -1173,6 +1173,10 @@ export const Items: {[k: string]: ModdedItemData} = {
 	},
 	safetygoggles: {
 		inherit: true,
+		onImmunity(type, pokemon) {
+			if (type === 'sandstorm' || type === 'hail' || type === 'acidrain' || type === 'bladerain' || type === 'powder') return false;
+		},
+		desc: "Holder is immune to powder moves and damage from Sandstorm, Hail, Acid Rain and Blade Rain.",
 		isNonstandard: null,
 	},
 	weaknesspolicy: {

--- a/data/mods/wack/moves.ts
+++ b/data/mods/wack/moves.ts
@@ -1,4 +1,108 @@
 export const Moves: {[k: string]: ModdedMoveData} = {
+	/* Modified vanilla moves */
+	gunkshot: {
+		inherit: true,
+		onModifyMove(move) {
+			if (this.field.isWeather(['acidrain'])) move.accuracy = true;
+		},
+		desc: "Has a 30% chance to poison the target. If the weather is Acid Rain, this move does not check accuracy.",
+		shortDesc: "30% chance to psn target. Can't miss in Acid Rain",
+		isNonstandard: null,
+	},
+	hurricane: {
+		inherit: true,
+		onModifyMove(move, pokemon, target) {
+			switch (target?.effectiveWeather()) {
+			case 'hail':
+			case 'snow':
+			case 'raindance':
+			case 'primordialsea':
+				move.accuracy = true;
+				break;
+			case 'sunnyday':
+			case 'desolateland':
+				move.accuracy = 50;
+				break;
+			}
+		},
+		desc: "Has a 30% chance to confuse the target. This move can hit a target using Bounce, Fly, or Sky Drop, or is under the effect of Sky Drop. If the weather is Primordial Sea, Rain Dance, Hail or Snow, this move does not check accuracy. If the weather is Desolate Land or Sunny Day, this move's accuracy is 50%. If this move is used against a Pokemon holding Utility Umbrella, this move's accuracy remains at 70%.",
+		shortDesc: "30% chance to confuse target. Can't miss in rain or hail.",
+		isNonstandard: null,
+	},
+	weatherball: {
+		inherit: true,
+		onModifyType(move, pokemon) {
+			switch (pokemon.effectiveWeather()) {
+			case 'sunnyday':
+			case 'desolateland':
+				move.type = 'Fire';
+				break;
+			case 'raindance':
+			case 'primordialsea':
+				move.type = 'Water';
+				break;
+			case 'sandstorm':
+				move.type = 'Rock';
+				break;
+			case 'hail':
+			case 'snow':
+				move.type = 'Ice';
+				break;
+			case 'acidrain':
+				move.type = 'Poison';
+				break;
+			case 'midnight':
+				move.type = 'Ghost';
+				break;
+			case 'bladerain':
+				move.type = 'Steel';
+				break;
+			}
+		},
+		onModifyMove(move, pokemon) {
+			switch (pokemon.effectiveWeather()) {
+			case 'sunnyday':
+			case 'desolateland':
+				move.basePower *= 2;
+				break;
+			case 'raindance':
+			case 'primordialsea':
+				move.basePower *= 2;
+				break;
+			case 'sandstorm':
+				move.basePower *= 2;
+				break;
+			case 'hail':
+			case 'snow':
+				move.basePower *= 2;
+				break;
+			case 'acidrain':
+				move.basePower *= 2;
+				break;
+			case 'midnight':
+				move.basePower *= 2;
+				break;
+			case 'bladerain':
+				move.basePower *= 2;
+				break;
+			}
+			this.debug('BP: ' + move.basePower);
+		},
+		desc: "Power doubles if a weather condition other than Delta Stream is active, and this move's type changes to match. Poison type during Acid Rain, Ghost type during Midnight, Steel type during Blade Rain, Ice type during Snow, Water type during Primordial Sea or Rain Dance, Rock type during Sandstorm, and Fire type during Desolate Land or Sunny Day. If the user is holding Utility Umbrella and uses Weather Ball during Primordial Sea, Rain Dance, Desolate Land, or Sunny Day, this move remains Normal type and does not double in power.",
+		isNonstandard: null,
+	},
+	venomdrench: {
+		inherit: true,
+		onHit(target, source, move) {
+			if (target.status === 'psn' || target.status === 'tox' || this.field.isWeather('acidrain')) {
+				return !!this.boost({atk: -1, spa: -1, spe: -1}, target, source, move);
+			}
+			return false;
+		},
+		desc: "Lowers the target's Attack, Special Attack, and Speed by 1 stage if the target is poisoned or Acid Rain is on the field. Fails if the target is not poisoned or Acid Rain isn't on the field.",
+		shortDesc: "Lowers Atk/Sp. Atk/Speed of poisoned foes/during acid rain by 1.",
+		isNonstandard: null,
+	},
 	/* Wack moves */
 	hijumpkick: {
 		inherit: true,

--- a/data/mods/wack/typechart.ts
+++ b/data/mods/wack/typechart.ts
@@ -572,6 +572,7 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	electric: {
 		damageTaken: {
+			par: 3,
 			Blood: 0,
 			Bone: 1,
 			Bug: 0,
@@ -857,6 +858,7 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	fire: {
 		damageTaken: {
+			brn: 3,
 			Blood: 0,
 			Bone: 0,
 			Bug: 2,
@@ -1028,6 +1030,8 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	ghost: {
 		damageTaken: {
+			trapped: 3,
+			bladerain: 3,
 			Blood: 3,
 			Bone: 2,
 			Bug: 2,
@@ -1142,6 +1146,7 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	grass: {
 		damageTaken: {
+			powder: 3,
 			Blood: 2,
 			Bone: 0,
 			Bug: 1,
@@ -1370,6 +1375,9 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	ice: {
 		damageTaken: {
+			hail: 3,
+			hyperboreanarctic: 3,
+			frz: 3,
 			Blood: 0,
 			Bone: 0,
 			Bug: 0,
@@ -1712,6 +1720,7 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	nuclear: {
 		damageTaken: {
+			acidrain: 3,
 			Blood: 0,
 			Bone: 0,
 			Bug: 1,
@@ -1997,6 +2006,8 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	poison: {
 		damageTaken: {
+			psn: 3,
+			tox: 3,
 			acidrain: 3,
 			Blood: 1,
 			Bone: 2,
@@ -2169,6 +2180,7 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	rock: {
 		damageTaken: {
+			sandstorm: 3,
 			Blood: 0,
 			Bone: 2,
 			Bug: 0,
@@ -2454,7 +2466,11 @@ export const TypeChart: {[k: string]: TypeData} = {
 	},
 	steel: {
 		damageTaken: {
+			psn: 3,
+			tox: 3,
+			sandstorm: 3,
 			acidrain: 3,
+			bladerain: 3,
 			Blood: 2,
 			Bone: 2,
 			Bug: 2,


### PR DESCRIPTION
## Description
- Fixed the abilities Pounce, Vespertine and Graze.
- Fixed vanilla types not having their status immunity in the Wack mod
- Fixed Aegislash's "Aegis" alias overwriting the Divine type move "Aegis"

- Adding Blade Rain and more weather interactions

- Adding Uber and banlists

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities