### PR TITLE
Small additions to last Wack update

### DIFF
--- a/data/mods/wack/formats-data.ts
+++ b/data/mods/wack/formats-data.ts
@@ -10497,7 +10497,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	poryrus: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	poryrusz: {
@@ -12777,7 +12777,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bremoraid: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	boctillery: {
@@ -12897,7 +12897,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	apichu: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	acleffa: {
@@ -13202,7 +13202,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bpoliwag: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	nyosuka: {
@@ -13227,7 +13227,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	devull: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bhoundoom: {
@@ -15327,7 +15327,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	golpsyduck: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	matriawak: {
@@ -15887,7 +15887,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	praticate: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	snowlax: {
@@ -18152,7 +18152,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	wchansey: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	wblissey: {
@@ -20782,7 +20782,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	primplup: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	primpendlup: {
@@ -21117,7 +21117,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	kaijuminccino: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	kaijucinccino: {
@@ -21387,12 +21387,12 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	sunsprout: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bwooper: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	feiscue: {
@@ -21427,7 +21427,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bchinchou: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	blanturn: {
@@ -21452,7 +21452,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bcyndaquil: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	acyndaquil: {
@@ -21647,7 +21647,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bhoothoot: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bsmantine: {
@@ -21662,12 +21662,12 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bslugma: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bpichu: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bblissey: {
@@ -21837,7 +21837,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bsentret: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bfurret: {
@@ -21847,7 +21847,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	btotodile: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bforretress: {
@@ -21902,7 +21902,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bsunkern: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	unfinkingdra: {
@@ -22117,7 +22117,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bellscrop: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	atlasbell: {
@@ -22127,7 +22127,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	hoppot: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	hoprake: {
@@ -22137,7 +22137,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	potish: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	trickish: {
@@ -22147,7 +22147,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	roseling: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	witherade: {
@@ -25417,7 +25417,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bgrotle: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	btorterra: {
@@ -25427,7 +25427,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bprinplup: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bempoleon: {
@@ -25437,7 +25437,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bshinx: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bachichi: {
@@ -25452,7 +25452,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bcranidos: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	brampardos: {
@@ -25462,7 +25462,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bcombee: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bvespiquen: {
@@ -25477,7 +25477,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bgible: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bgabite: {
@@ -25492,7 +25492,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bhippopotas: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	bhippowdon: {
@@ -25507,7 +25507,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bfinneon: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	blumineon: {
@@ -25517,7 +25517,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bsnover: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	babomasnow: {
@@ -26647,7 +26647,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	btorchic: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	latiaziken: {
@@ -26717,7 +26717,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	krampird: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	santajynx: {
@@ -27737,7 +27737,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	fedorakirlia: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	excitebike: {
@@ -28737,7 +28737,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	hgrowlithe: {
 		inherit: true,
-		tier: "LC",
+		tier: "NFE",
 		isNonstandard: null,
 	},
 	harcanine: {

--- a/data/mods/wack/pokedex.ts
+++ b/data/mods/wack/pokedex.ts
@@ -2294,5 +2294,726 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	hoopa: {
 		inherit: true,
 		abilities: {0: "Prankster"},
-	}
+	},
+	rowlet: {
+		inherit: true,
+		abilities: {0: "Overgrow", H: "Unburden"},
+	},
+	dartrix: {
+		inherit: true,
+		baseStats: {hp: 78, atk: 75, def: 75, spa: 70, spd: 70, spe: 62},
+		abilities: {0: "Overgrow", H: "Unburden"},
+	},
+	decidueye: {
+		inherit: true,
+		baseStats: {hp: 78, atk: 107, def: 73, spa: 100, spd: 100, spe: 74},
+		abilities: {0: "Compound Eyes", 1: "Sniper", H: "Unburden"},
+	},
+	litten: {
+		inherit: true,
+		abilities: {0: "Blaze", H: "Solar Power"},
+	},
+	incineroar: {
+		inherit: true,
+		baseStats: {hp: 95, atk: 115, def: 90, spa: 80, spd: 90, spe: 65},
+		abilities: {0: "Intimidate", 1: "Blaze"},
+	},
+	popplio: {
+		inherit: true,
+		abilities: {0: "Torrent", H: "Rain Dish"},
+	},
+	brionne: {
+		inherit: true,
+		abilities: {0: "Torrent", H: "Rain Dish"},
+	},
+	primarina: {
+		inherit: true,
+		abilities: {0: "Cacophony", 1: "Soundproof", H: "Hydrate"},
+	},
+	pikipek: {
+		inherit: true,
+		baseStats: {hp: 35, atk: 75, def: 30, spa: 30, spd: 65, spe: 55},
+		abilities: {0: "Keen Eye", 1: "Skill Link", H: "Big Pecks"},
+	},
+	trumbeak: {
+		inherit: true,
+		baseStats: {hp: 55, atk: 85, def: 50, spa: 50, spd: 75, spe: 70},
+		abilities: {0: "Keen Eye", 1: "Skill Link", H: "Big Pecks"},
+	},
+	toucannon: {
+		inherit: true,
+		baseStats: {hp: 80, atk: 120, def: 75, spa: 75, spd: 75, spe: 105},
+		abilities: {0: "Keen Eye", 1: "Skill Link", H: "Flame Body"},
+	},
+	yungoos: {
+		inherit: true,
+		baseStats: {hp: 48, atk: 30, def: 41, spa: 30, spd: 41, spe: 60},
+		abilities: {0: "Strong Jaw", 1: "Adaptability", H: "Quick Feet"},
+	},
+	gumshoos: {
+		inherit: true,
+		baseStats: {hp: 88, atk: 110, def: 80, spa: 55, spd: 60, spe: 45},
+		abilities: {0: "Strong Jaw", 1: "Analytic"},
+	},
+	grubbin: {
+		inherit: true,
+		abilities: {0: "Swarm", H: "Run Away"},
+	},
+	charjabug: {
+		inherit: true,
+		abilities: {0: "Static", H: "Motor Drive"},
+	},
+	vikavolt: {
+		inherit: true,
+		baseStats: {hp: 77, atk: 70, def: 80, spa: 145, spd: 75, spe: 100},
+		abilities: {0: "Levitate", H: "Speed Boost"},
+	},
+	crabrawler: {
+		inherit: true,
+		baseStats: {hp: 47, atk: 88, def: 63, spa: 47, spd: 63, spe: 50},
+		abilities: {0: "Iron Fist", 1: "Anger Point", H: "Hyper Cutter"},
+	},
+	crabominable: {
+		inherit: true,
+		baseStats: {hp: 97, atk: 138, def: 81, spa: 60, spd: 81, spe: 60},
+		abilities: {0: "Iron Fist", 1: "Fur Coat", H: "Snow Rush"},
+	},
+	oricorio: {
+		inherit: true,
+		abilities: {0: "Insomnia"},
+	},
+	cutiefly: {
+		inherit: true,
+		abilities: {0: "Shield Dust", 1: "Honey Gather", H: "Filter"},
+	},
+	ribombee: {
+		inherit: true,
+		baseStats: {hp: 80, atk: 55, def: 60, spa: 95, spd: 70, spe: 125},
+		abilities: {0: "Shield Dust", 1: "Honey Gather", H: "Filter"},
+	},
+	rockruff: {
+		inherit: true,
+		abilities: {0: "Keen Eye", 1: "Insomnia", H: "Quick Feet"},
+	},
+	dlycanroc: {
+		inherit: true,
+		types: ["Rock", "Light"],
+		baseStats: {hp: 75, atk: 120, def: 65, spa: 55, spd: 65, spe: 112},
+		abilities: {0: "Sheer Force", 1: "Sand Rush", H: "Quick Feet"},
+	},
+	nlycanroc: {
+		inherit: true,
+		types: ["Rock", "Fighting"],
+		baseStats: {hp: 85, atk: 120, def: 86, spa: 38, spd: 81, spe: 82},
+		abilities: {0: "No Guard", 1: "Insomnia", H: "Quick Feet"},
+	},
+	wishiwashi: {
+		inherit: true,
+		baseStats: {hp: 80, atk: 140, def: 130, spa: 140, spd: 135, spe: 40},
+		abilities: {0: "Water Veil"},
+	},
+	mareanie: {
+		inherit: true,
+		types: ["Water", "Poison"],
+		baseStats: {hp: 50, atk: 53, def: 62, spa: 52, spd: 45, spe: 43},
+		abilities: {0: "Limber", 1: "Regenerator", H: "Merciless"},
+	},
+	toxapex: {
+		inherit: true,
+		types: ["Water", "Poison"],
+		abilities: {0: "Limber", 1: "Merciless"},
+	},
+	mudsdale: {
+		inherit: true,
+		baseStats: {hp: 100, atk: 125, def: 100, spa: 45, spd: 85, spe: 70},
+	},
+	dewpider: {
+		inherit: true,
+		abilities: {0: "Water Veil", H: "Rain Dish"},
+	},
+	araquanid: {
+		inherit: true,
+		abilities: {0: "Water Veil", H: "Rain Dish"},
+	},
+	fomantis: {
+		inherit: true,
+		abilities: {0: "Leaf Guard", 1: "Contrary", H: "Regenerator"},
+	},
+	lurantis: {
+		inherit: true,
+		baseStats: {hp: 70, atk: 105, def: 90, spa: 100, spd: 90, spe: 45},
+		abilities: {0: "Leaf Guard", 1: "Contrary", H: "Regenerator"},
+	},
+	morelull: {
+		inherit: true,
+		abilities: {0: "Effect Spore", 1: "Rain Dish", H: "Illuminate"},
+	},
+	shiinotic: {
+		inherit: true,
+		baseStats: {hp: 100, atk: 45, def: 80, spa: 90, spd: 100, spe: 30},
+		abilities: {0: "Effect Spore", 1: "Rain Dish", H: "Illuminate"},
+	},
+	salandit: {
+		inherit: true,
+		types: ["Fire", "Poison"],
+		abilities: {0: "Scrappy"},
+	},
+	salazzle: {
+		inherit: true,
+		types: ["Fire", "Poison"],
+		abilities: {0: "Scrappy", H: "Acid Rush"},
+	},
+	stufful: {
+		inherit: true,
+		abilities: {0: "Fur Coat", 1: "Cute Charm", H: "Klutz"},
+	},
+	bewear: {
+		inherit: true,
+		abilities: {0: "Fur Coat", 1: "Unnerve", H: "Klutz"},
+	},
+	bounsweet: {
+		inherit: true,
+		abilities: {0: "Oblivious", 1: "Leaf Guard"},
+	},
+	steenee: {
+		inherit: true,
+		abilities: {0: "Oblivious", 1: "Leaf Guard"},
+	},
+	tsareena: {
+		inherit: true,
+		baseStats: {hp: 78, atk: 120, def: 100, spa: 70, spd: 98, spe: 82},
+		abilities: {0: "Dazzling", 1: "Furious Feet"},
+	},
+	comfey: {
+		inherit: true,
+		abilities: {0: "Natural Cure", 1: "Prankster", H: "Healer"},
+	},
+	oranguru: {
+		inherit: true,
+		abilities: {0: "Inner Focus", H: "Sap Sipper"},
+	},
+	passimian: {
+		inherit: true,
+		baseStats: {hp: 100, atk: 120, def: 90, spa: 40, spd: 60, spe: 85},
+		abilities: {0: "Defiant", H: "Inner Focus"},
+	},
+	wimpod: {
+		inherit: true,
+		abilities: {0: "Defeatist", H: "Rain Dish"},
+	},
+	golisopod: {
+		inherit: true,
+		baseStats: {hp: 75, atk: 125, def: 140, spa: 60, spd: 90, spe: 50},
+		abilities: {0: "Guts", 1: "Battle Armor", H: "Intimidate"},
+	},
+	sandygast: {
+		inherit: true,
+		abilities: {0: "Water Absorb"},
+	},
+	palossand: {
+		inherit: true,
+		baseStats: {hp: 85, atk: 75, def: 110, spa: 100, spd: 85, spe: 35},
+		abilities: {0: "Water Absorb"},
+	},
+	pyukumuku: {
+		inherit: true,
+		baseStats: {hp: 65, atk: 60, def: 130, spa: 40, spd: 130, spe: 5},
+		abilities: {0: "Aftermath", 1: "Unaware", H: "Hydration"},
+	},
+	silvally: {
+		inherit: true,
+		baseStats: {hp: 100, atk: 100, def: 95, spa: 100, spd: 95, spe: 100},
+		abilities: {0: "Multitype"},
+	},
+	minior: {
+		inherit: true,
+		types: ["Flying", "Rock"],
+		baseStats: {hp: 60, atk: 60, def: 125, spa: 60, spd: 125, spe: 60},
+		abilities: {0: "Zen Mode", H: "Moody"},
+	},
+	komala: {
+		inherit: true,
+		baseStats: {hp: 75, atk: 110, def: 90, spa: 85, spd: 75, spe: 65},
+		abilities: {0: "Early Bird"},
+	},
+	turtonator: {
+		inherit: true,
+		abilities: {0: "Battle Armor", H: "Sheer Force"},
+	},
+	togedemaru: {
+		inherit: true,
+		baseStats: {hp: 67, atk: 58, def: 57, spa: 81, spd: 67, spe: 101},
+		abilities: {0: "Rough Skin", 1: "Lightning Rod"},
+	},
+	mimikyu: {
+		inherit: true,
+		baseStats: {hp: 75, atk: 90, def: 95, spa: 50, spd: 105, spe: 96},
+		abilities: {0: "Multiscale", H: "Cursed Body"},
+	},
+	bruxish: {
+		inherit: true,
+		baseStats: {hp: 70, atk: 115, def: 75, spa: 70, spd: 75, spe: 105},
+		abilities: {0: "Strong Jaw", 1: "Dazzling"},
+	},
+	drampa: {
+		inherit: true,
+		abilities: {0: "Sap Sipper", 1: "Berserk"},
+	},
+	dhelmise: {
+		inherit: true,
+		abilities: {0: "Metalworker", H: "Heatproof"},
+	},
+	jangmoo: {
+		inherit: true,
+		abilities: {0: "Soundproof", 1: "Bulletproof"},
+	},
+	hakamoo: {
+		inherit: true,
+		abilities: {0: "Soundproof", 1: "Bulletproof"},
+	},
+	kommoo: {
+		inherit: true,
+		abilities: {0: "Soundproof", 1: "Bulletproof"},
+	},
+	tapukoko: {
+		inherit: true,
+		abilities: {0: "Inner Focus", H: "Anger Point"},
+	},
+	tapulele: {
+		inherit: true,
+		abilities: {0: "Cute Charm", H: "Magic Guard"},
+	},
+	tapubulu: {
+		inherit: true,
+		abilities: {0: "Anger Point", H: "Chlorophyll"},
+	},
+	tapufini: {
+		inherit: true,
+		abilities: {0: "Rain Dish"},
+	},
+	cosmog: {
+		inherit: true,
+		types: ["Cosmic"],
+		baseStats: {hp: 43, atk: 60, def: 41, spa: 60, spd: 41, spe: 67},
+		abilities: {0: "Unaware", H: "Run Away"},
+	},
+	cosmoem: {
+		inherit: true,
+		types: ["Cosmic"],
+		baseStats: {hp: 43, atk: 30, def: 131, spa: 30, spd: 131, spe: 37},
+		abilities: {0: "Sturdy", H: "Filter"},
+	},
+	solgaleo: {
+		inherit: true,
+		types: ["Cosmic", "Steel"],
+		abilities: {0: "Clear Body", H: "Drought"},
+	},
+	lunala: {
+		inherit: true,
+		types: ["Cosmic", "Ghost"],
+		abilities: {0: "Multiscale", H: "Shadow Call"},
+	},
+	nihilego: {
+		inherit: true,
+		abilities: {0: "Beast Boost", H: "Suction Cups"},
+	},
+	buzzwole: {
+		inherit: true,
+		abilities: {0: "Beast Boost", H: "Siphon"},
+	},
+	pheromosa: {
+		inherit: true,
+		abilities: {0: "Beast Boost", H: "Furious Feet"},
+	},
+	xurkitree: {
+		inherit: true,
+		abilities: {0: "Beast Boost", H: "Lightning Rod"},
+	},
+	celesteela: {
+		inherit: true,
+		abilities: {0: "Beast Boost", H: "Sap Sipper"},
+	},
+	kartana: {
+		inherit: true,
+		abilities: {0: "Beast Boost", H: "Hyper Cutter"},
+	},
+	guzzlord: {
+		inherit: true,
+		abilities: {0: "Beast Boost", H: "Skeptic"},
+	},
+	necrozma: {
+		inherit: true,
+		abilities: {0: "Filter", H: "Battle Armor"},
+	},
+	magearna: {
+		inherit: true,
+		abilities: {0: "Pride", H: "Plus"},
+	},
+	marshadow: {
+		inherit: true,
+		abilities: {0: "Technician", H: "Soul Eater"},
+	},
+	stakataka: {
+		inherit: true,
+		baseStats: {hp: 71, atk: 131, def: 211, spa: 54, spd: 101, spe: 13},
+	},
+	zeraora: {
+		inherit: true,
+		baseStats: {hp: 88, atk: 112, def: 75, spa: 102, spd: 80, spe: 140},
+	},
+	melmetal: {
+		inherit: true,
+		baseStats: {hp: 135, atk: 143, def: 143, spa: 80, spd: 65, spe: 55},
+		abilities: {0: "Iron Fist", H: "Magnet Pull"},
+	},
+	grookey: {
+		inherit: true,
+		abilities: {0: "Overgrow", H: "Mold Breaker"},
+	},
+	thwackey: {
+		inherit: true,
+		baseStats: {hp: 70, atk: 85, def: 70, spa: 60, spd: 80, spe: 80},
+		abilities: {0: "Overgrow", H: "Mold Breaker"},
+	},
+	rillaboom: {
+		inherit: true,
+		types: ["Grass", "Sound"],
+		abilities: {0: "Overgrow", H: "Mold Breaker"},
+	},
+	scorbunny: {
+		inherit: true,
+		abilities: {0: "Blaze", H: "Furious Feet"},
+	},
+	raboot: {
+		inherit: true,
+		baseStats: {hp: 60, atk: 76, def: 60, spa: 55, spd: 60, spe: 94},
+		abilities: {0: "Blaze", H: "Furious Feet"},
+	},
+	cinderace: {
+		inherit: true,
+		types: ["Fire", "Electric"],
+		baseStats: {hp: 80, atk: 116, def: 75, spa: 65, spd: 75, spe: 120},
+		abilities: {0: "Blaze", H: "Furious Feet"},
+	},
+	sobble: {
+		inherit: true,
+		abilities: {0: "Torrent", H: "Defeatist"},
+	},
+	drizzile: {
+		inherit: true,
+		abilities: {0: "Torrent", H: "Unaware"},
+	},
+	inteleon: {
+		inherit: true,
+		types: ["Water", "Dark"],
+	},
+	skwovet: {
+		inherit: true,
+		abilities: {0: "Gluttony", H: "Pickpocket"},
+	},
+	greedent: {
+		inherit: true,
+		baseStats: {hp: 133, atk: 105, def: 100, spa: 65, spd: 75, spe: 26},
+		abilities: {0: "Gluttony", H: "Pickpocket"},
+	},
+	corvisquire: {
+		inherit: true,
+		abilities: {0: "Pressure", 1: "Big Pecks", H: "Battle Armor"},
+	},
+	corviknight: {
+		inherit: true,
+		baseStats: {hp: 98, atk: 87, def: 105, spa: 54, spd: 85, spe: 67},
+		abilities: {0: "Pressure", 1: "Unnerve", H: "Battle Armor"},
+	},
+	blipbug: {
+		inherit: true,
+		abilities: {0: "Swarm", 1: "Compound Eyes", H: "Run Away"},
+	},
+	dottler: {
+		inherit: true,
+		abilities: {0: "Swarm", 1: "Compound Eyes", H: "Wonder Skin"},
+	},
+	orbeetle: {
+		inherit: true,
+		baseStats: {hp: 60, atk: 45, def: 110, spa: 85, spd: 120, spe: 90},
+		abilities: {0: "Tinted Lens", 1: "Wonder Skin", H: "Swarm"},
+	},
+	thievul: {
+		inherit: true,
+		baseStats: {hp: 70, atk: 90, def: 58, spa: 93, spd: 92, spe: 105},
+		abilities: {0: "Unburden", H: "Detonator"},
+	},
+	gossifleur: {
+		inherit: true,
+		baseStats: {hp: 40, atk: 40, def: 65, spa: 40, spd: 70, spe: 10},
+		abilities: {0: "Gooey", 1: "Regenerator", H: "Chlorophyll"},
+	},
+	eldegoss: {
+		inherit: true,
+		baseStats: {hp: 66, atk: 64, def: 100, spa: 85, spd: 128, spe: 72},
+		abilities: {0: "Gooey", 1: "Regenerator", H: "Chlorophyll"},
+	},
+	wooloo: {
+		inherit: true,
+		baseStats: {hp: 42, atk: 40, def: 55, spa: 45, spd: 48, spe: 48},
+		abilities: {0: "Fur Coat", 1: "Run Away", H: "Adaptability"},
+	},
+	dubwool: {
+		inherit: true,
+		baseStats: {hp: 72, atk: 81, def: 100, spa: 62, spd: 90, spe: 88},
+		abilities: {0: "Fur Coat", 1: "Steadfast"},
+	},
+	chewtle: {
+		inherit: true,
+		abilities: {0: "Strong Jaw", 1: "Battle Armor", H: "Rough Skin"},
+	},
+	drednaw: {
+		inherit: true,
+		baseStats: {hp: 90, atk: 120, def: 95, spa: 48, spd: 70, spe: 74},
+		abilities: {0: "Strong Jaw", 1: "Battle Armor", H: "Rough Skin"},
+	},
+	yamper: {
+		inherit: true,
+		abilities: {0: "Static", 1: "Pickup", H: "Plus"},
+	},
+	boltund: {
+		inherit: true,
+		baseStats: {hp: 75, atk: 95, def: 70, spa: 101, spd: 69, spe: 135},
+		abilities: {0: "Static", 1: "Strong Jaw", H: "Speed Boost"},
+	},
+	rolycoly: {
+		inherit: true,
+		baseStats: {hp: 30, atk: 40, def: 55, spa: 45, spd: 55, spe: 30},
+		abilities: {0: "Steam Engine", 1: "Flash Fire", H: "Heatproof"},
+	},
+	coalossal: {
+		inherit: true,
+		baseStats: {hp: 121, atk: 90, def: 128, spa: 86, spd: 96, spe: 40},
+		abilities: {0: "Steam Engine", 1: "Flash Fire", H: "Filter"},
+	},
+	applin: {
+		inherit: true,
+		baseStats: {hp: 45, atk: 50, def: 35, spa: 55, spd: 75, spe: 40},
+		abilities: {0: "Gluttony"},
+	},
+	flapple: {
+		inherit: true,
+		baseStats: {hp: 70, atk: 110, def: 70, spa: 95, spd: 60, spe: 110},
+		abilities: {0: "Levitate", 1: "Hustle", H: "Weak Armor"},
+	},
+	appletun: {
+		inherit: true,
+		abilities: {0: "Thick Fat", H: "Graze"},
+	},
+	silicobra: {
+		inherit: true,
+		abilities: {0: "Shed Skin", 1: "Sand Veil", H: "Cold Blooded"},
+	},
+	sandaconda: {
+		inherit: true,
+		baseStats: {hp: 83, atk: 111, def: 139, spa: 75, spd: 83, spe: 86},
+		abilities: {0: "Shed Skin", 1: "Sand Veil", H: "Cold Blooded"},
+	},
+	cramorant: {
+		inherit: true,
+		baseStats: {hp: 70, atk: 85, def: 75, spa: 120, spd: 75, spe: 90},
+		abilities: {0: "Parental Bond", H: "Water Absorb"},
+	},
+	arrokuda: {
+		inherit: true,
+		baseStats: {hp: 51, atk: 90, def: 45, spa: 50, spd: 30, spe: 100},
+		abilities: {0: "Swift Swim", H: "Mold Breaker"},
+	},
+	barraskewda: {
+		inherit: true,
+		abilities: {0: "Swift Swim", H: "Mold Breaker"},
+	},
+	toxel: {
+		inherit: true,
+		types: ["Poison", "Electric"],
+		abilities: {0: "Rattled", 1: "Static", H: "Competitive"},
+	},
+	toxtricity: {
+		inherit: true,
+		types: ["Poison", "Electric"],
+		baseStats: {hp: 75, atk: 98, def: 75, spa: 114, spd: 80, spe: 75},
+		abilities: {0: "Cacophony", 1: "Plus"},
+	},
+	sizzlipede: {
+		inherit: true,
+		abilities: {0: "White Smoke", 1: "Flash Fire"},
+	},
+	centiskorch: {
+		inherit: true,
+		baseStats: {hp: 107, atk: 119, def: 83, spa: 104, spd: 106, spe: 102},
+		abilities: {0: "White Smoke", 1: "Flash Fire"},
+	},
+	clobbopus: {
+		inherit: true,
+		abilities: {0: "Guts", 1: "Limber", H: "Infiltrator"},
+	},
+	grapploct: {
+		inherit: true,
+		baseStats: {hp: 95, atk: 123, def: 99, spa: 82, spd: 90, spe: 48},
+		abilities: {0: "Guts", 1: "Limber", H: "Suction Cups"},
+	},
+	polteageist: {
+		inherit: true,
+		baseStats: {hp: 74, atk: 68, def: 71, spa: 144, spd: 119, spe: 73},
+		abilities: {0: "Weak Armor", H: "Water Absorb"},
+	},
+	hattrem: {
+		inherit: true,
+		baseStats: {hp: 57, atk: 50, def: 65, spa: 86, spd: 76, spe: 49},
+		abilities: {0: "Anticipation", 1: "Healer", H: "Anger Point"},
+	},
+	hatterene: {
+		inherit: true,
+		baseStats: {hp: 61, atk: 90, def: 96, spa: 136, spd: 103, spe: 44},
+		abilities: {0: "Anticipation", 1: "Healer", H: "Anger Point"},
+	},
+	morgrem: {
+		inherit: true,
+		baseStats: {hp: 65, atk: 65, def: 45, spa: 75, spd: 55, spe: 70},
+	},
+	grimmsnarl: {
+		inherit: true,
+		baseStats: {hp: 95, atk: 120, def: 75, spa: 95, spd: 85, spe: 60},
+		abilities: {0: "Prankster", 1: "Frisk", H: "Anger Point"},
+	},
+	obstagoon: {
+		inherit: true,
+		baseStats: {hp: 102, atk: 92, def: 109, spa: 63, spd: 105, spe: 101},
+		abilities: {0: "Reckless", 1: "Guts", H: "Tough Claws"},
+	},
+	perrserker: {
+		inherit: true,
+		baseStats: {hp: 80, atk: 124, def: 110, spa: 59, spd: 68, spe: 58},
+		abilities: {0: "Tough Claws", 1: "Battle Armor", H: "Berserker"},
+	},
+	cursola: {
+		inherit: true,
+		baseStats: {hp: 65, atk: 106, def: 63, spa: 156, spd: 133, spe: 35},
+		abilities: {0: "Weak Armor", H: "Cursed Body"},
+	},
+	sirfetchd: {
+		inherit: true,
+		baseStats: {hp: 72, atk: 130, def: 105, spa: 50, spd: 82, spe: 105},
+		abilities: {0: "Steadfast", H: "Guts"},
+	},
+	mrrime: {
+		inherit: true,
+		types: ["Psychic", "Ice"],
+		abilities: {0: "Tangled Feet", 1: "Ice Body", H: "Truant"},
+	},
+	runerigus: {
+		inherit: true,
+		types: ["Ghost", "Ground"],
+		abilities: {0: "Mummy"},
+	},
+	milcery: {
+		inherit: true,
+		types: ["Fairy", "Food"],
+		baseStats: {hp: 68, atk: 49, def: 56, spa: 66, spd: 134, spe: 50},
+		abilities: {0: "Sweet Veil", H: "Cute Charm"},
+	},
+	alcremie: {
+		inherit: true,
+		types: ["Fairy", "Food"],
+		baseStats: {hp: 105, atk: 70, def: 89, spa: 90, spd: 134, spe: 62},
+		abilities: {0: "Sweet Veil", H: "Cute Charm"},
+	},
+	falinks: {
+		inherit: true,
+		baseStats: {hp: 65, atk: 100, def: 100, spa: 70, spd: 60, spe: 85},
+		abilities: {0: "Battle Armor", H: "Skill Link"},
+	},
+	pincurchin: {
+		inherit: true,
+		baseStats: {hp: 56, atk: 98, def: 109, spa: 102, spd: 90, spe: 21},
+		abilities: {0: "Lightning Rod", H: "Rough Skin"},
+	},
+	snom: {
+		inherit: true,
+		abilities: {0: "Shield Dust", 1: "Isolation", H: "Swarm"},
+	},
+	frosmoth: {
+		inherit: true,
+		baseStats: {hp: 81, atk: 75, def: 76, spa: 130, spd: 100, spe: 105},
+		abilities: {0: "Shield Dust", 1: "Isolation", H: "Snow Warning"},
+	},
+	stonjourner: {
+		inherit: true,
+		baseStats: {hp: 100, atk: 125, def: 145, spa: 20, spd: 20, spe: 70},
+		abilities: {0: "Victory Star"},
+	},
+	eiscue: {
+		inherit: true,
+		baseStats: {hp: 80, atk: 82, def: 176, spa: 70, spd: 130, spe: 55},
+		abilities: {0: "Multiscale", H: "Ice Body"},
+	},
+	indeedee: {
+		inherit: true,
+		baseStats: {hp: 79, atk: 59, def: 68, spa: 107, spd: 116, spe: 98},
+		abilities: {0: "Inner Focus", 1: "Synchronize", H: "Own Tempo"},
+	},
+	morpeko: {
+		inherit: true,
+		baseStats: {hp: 75, atk: 95, def: 68, spa: 70, spd: 68, spe: 97},
+		abilities: {0: "Zen Mode", H: "Lightning Rod"},
+	},
+	cufant: {
+		inherit: true,
+		abilities: {0: "Sheer Force", H: "Battle Armor"},
+	},
+	copperajah: {
+		inherit: true,
+		baseStats: {hp: 122, atk: 130, def: 70, spa: 80, spd: 68, spe: 30},
+		abilities: {0: "Sheer Force", H: "Lightning Rod", S: "Immunity"},
+	},
+	arctozolt: {
+		inherit: true,
+		abilities: {0: "Volt Absorb", 1: "Static", H: "Snow Rush"},
+	},
+	arctovish: {
+		inherit: true,
+		baseStats: {hp: 90, atk: 90, def: 100, spa: 90, spd: 55, spe: 80},
+		abilities: {0: "Water Absorb", 1: "Ice Body", H: "Snow Rush"},
+	},
+	duraludon: {
+		inherit: true,
+		baseStats: {hp: 70, atk: 95, def: 115, spa: 120, spd: 65, spe: 95},
+		abilities: {0: "Inner Focus", H: "Stamina"},
+	},
+	dreepy: {
+		inherit: true,
+		abilities: {0: "Clear Body", 1: "Infiltrator", H: "Rough Skin"},
+	},
+	drakloak: {
+		inherit: true,
+		baseStats: {hp: 68, atk: 80, def: 50, spa: 65, spd: 85, spe: 102},
+		abilities: {0: "Clear Body", 1: "Infiltrator", H: "Rough Skin"},
+	},
+	dragapult: {
+		inherit: true,
+		abilities: {0: "Clear Body", 1: "Infiltrator", H: "Rough Skin"},
+	},
+	zacian: {
+		inherit: true,
+		types: ["Fairy", "Steel"],
+		abilities: {0: "Justified"},
+	},
+	eternatus: {
+		inherit: true,
+		abilities: {0: "Pressure", H: "Beast Boost"},
+	},
+	kubfu: {
+		inherit: true,
+		abilities: {0: "Inner Focus", H: "Steadfast"},
+	},
+	zarude: {
+		inherit: true,
+		baseStats: {hp: 85, atk: 125, def: 90, spa: 105, spd: 80, spe: 127},
+		abilities: {0: "Leaf Guard", H: "Sand Stream"},
+	},
 }

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -46346,7 +46346,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 0.1,
 		color: "White",
-		evos : ["Encyclodia", "Swanaper", "Pagolem", "C Encyclodia"],
+		evos : ["C Encyclodia", "Pagolem", "Swanaper", "Encyclodia"],
 		eggGroups: ["Field"],
 	},
 	swanaper: {
@@ -46479,6 +46479,7 @@ blobbosmechelectric: {
 		heightm: 12.1,
 		weightkg: 1000.0,
 		color: "Red",
+		prevo : "Solrock",
 		eggGroups: ["Mineral"],
 	},
 	lunighton: {
@@ -46490,6 +46491,7 @@ blobbosmechelectric: {
 		heightm: 10.0,
 		weightkg: 468.0,
 		color: "Yellow",
+		prevo : "Lunatone",
 		eggGroups: ["Mineral"],
 	},
 	chipit: {
@@ -46525,7 +46527,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 21.0,
 		color: "Purple",
-		evos : ["Hundead", "Chillzie", "Zomboom", "Smobill"],
+		evos : ["Hundead", "Zomboom", "Smobill", "Chillzie"],
 		eggGroups: ["Humanlike"],
 	},
 	hundead: {
@@ -46969,7 +46971,7 @@ blobbosmechelectric: {
 		heightm: 3.9,
 		weightkg: 29.7,
 		color: "Purple",
-		evos : ["Elechair", "Tenablerus"],
+		evos : ["Tenablerus", "Elechair"],
 		eggGroups: ["Amorphous"],
 	},
 	tenablerus: {
@@ -47063,7 +47065,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 21.0,
 		color: "Purple",
-		evos : ["Snapchost", "Feborius", "Tweeter", "Steamercom", "Myosmic"],
+		evos : ["Tweeter", "Snapchost", "Steamercom", "Feborius", "Myosmic"],
 		eggGroups: ["Undiscovered"],
 	},
 	tweeter: {
@@ -47495,7 +47497,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 104.5,
 		color: "Red",
-		evos : ["Orderymid", "Eyeluminid", "Chaosemple"],
+		evos : ["Chaosemple", "Eyeluminid", "Orderymid"],
 		eggGroups: ["Mineral"],
 	},
 	chaosemple: {
@@ -47602,6 +47604,7 @@ blobbosmechelectric: {
 		heightm: 4.6,
 		weightkg: 50.4,
 		color: "Purple",
+		prevo : "Ditto",
 		eggGroups: ["Ditto"],
 	},
 	orscine: {
@@ -47637,7 +47640,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 21.0,
 		color: "Purple",
-		evos : ["Zombeast", "Wiondeath"],
+		evos : ["Wiondeath", "Zombeast"],
 		eggGroups: ["Undiscovered"],
 	},
 	zombeast: {
@@ -47697,7 +47700,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 33.5,
 		color: "Blue",
-		evos : ["Chernophoot", "Behemist"],
+		evos : ["Behemist", "Chernophoot"],
 		eggGroups: ["Field"],
 	},
 	behemist: {
@@ -48083,7 +48086,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 40.0,
 		color: "White",
-		evos : ["Ijusgotsmal", "Ijusgotbigger"],
+		evos : ["Ijusgotbigger", "Ijusgotsmal"],
 		eggGroups: ["Monster"],
 	},
 	ijusgotbigger: {
@@ -48119,6 +48122,7 @@ blobbosmechelectric: {
 		heightm: 2.8,
 		weightkg: 100.8,
 		color: "Blue",
+		prevo : "Sharpedo",
 		eggGroups: ["Water2"],
 	},
 	ancienkrab: {
@@ -48130,6 +48134,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 60.0,
 		color: "Red",
+		prevo : "Kingler",
 		eggGroups: ["Water3"],
 	},
 	fedoraz: {
@@ -48393,6 +48398,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 1.0,
 		color: "Blue",
+		prevo : "Chimecho",
 		eggGroups: ["Amorphous"],
 	},
 	datagon: {
@@ -48894,7 +48900,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 21.0,
 		color: "White",
-		evos : ["Tauros", "Miltank", "Holeecow"],
+		evos : ["Holeecow", "Miltank", "Tauros"],
 		eggGroups: ["Undiscovered"],
 	},
 	medijaa: {
@@ -48906,6 +48912,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 31.5,
 		color: "Blue",
+		prevo : "Medicham",
 		eggGroups: ["Humanlike"],
 	},
 	audinette: {
@@ -48917,6 +48924,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 31.0,
 		color: "Pink",
+		prevo : "Audino",
 		eggGroups: ["Fairy"],
 	},
 	nanos: {
@@ -48928,7 +48936,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 18.5,
 		color: "Gray",
-		evos : ["Propod", "Propad"],
+		evos : ["Propad", "Propod"],
 		eggGroups: ["Mineral", "Amorphous"],
 	},
 	propod: {
@@ -49000,6 +49008,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 32.5,
 		color: "Red",
+		prevo : "Porygon",
 		evos : ["Poryrusz"],
 		eggGroups: ["Mineral"],
 	},
@@ -49024,7 +49033,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 50.5,
 		color: "Gray",
-		evos : ["Spacird", "Jetcraft"],
+		evos : ["Jetcraft", "Spacird"],
 		eggGroups: ["Flying"],
 	},
 	jetcraft: {
@@ -49048,6 +49057,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 14.0,
 		color: "Yellow",
+		prevo : "Dunsparce",
 		eggGroups: ["Field", "Dragon"],
 	},
 	dunesdrill: {
@@ -49059,6 +49069,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 14.0,
 		color: "Yellow",
+		prevo : "Dunsparce",
 		eggGroups: ["Field"],
 	},
 	dunsparth: {
@@ -49070,6 +49081,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 14.0,
 		color: "Yellow",
+		prevo : "Dunsparce",
 		eggGroups: ["Field"],
 	},
 	vespiguard: {
@@ -49081,6 +49093,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 38.5,
 		color: "Yellow",
+		prevo : "Combee",
 		eggGroups: ["Bug"],
 	},
 	lapsy: {
@@ -49260,6 +49273,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 26.5,
 		color: "Purple",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	spaceon: {
@@ -49271,6 +49285,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 26.5,
 		color: "Purple",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	zyklas: {
@@ -49426,6 +49441,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 24.5,
 		color: "Yellow",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	snowdoge: {
@@ -49485,6 +49501,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 20.6,
 		color: "Blue",
+		prevo : "Altaria",
 		eggGroups: ["Flying", "Dragon"],
 	},
 	camerano: {
@@ -49496,6 +49513,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 220.0,
 		color: "Red",
+		prevo : "Camerupt",
 		eggGroups: ["Field"],
 	},
 	sharpoat: {
@@ -49507,6 +49525,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 88.8,
 		color: "Blue",
+		prevo : "Sharpedo",
 		eggGroups: ["Water2"],
 	},
 	houndhell: {
@@ -49518,6 +49537,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 35.0,
 		color: "Black",
+		prevo : "Houndoom",
 		eggGroups: ["Field"],
 	},
 	pinswing: {
@@ -49529,6 +49549,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 55.0,
 		color: "Brown",
+		prevo : "Pinsir",
 		eggGroups: ["Bug"],
 	},
 	aerodactold: {
@@ -49540,6 +49561,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 59.0,
 		color: "Purple",
+		prevo : "Aerodactyl",
 		eggGroups: ["Flying"],
 	},
 	herculecross: {
@@ -49551,6 +49573,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 54.0,
 		color: "Blue",
+		prevo : "Heracross",
 		eggGroups: ["Bug"],
 	},
 	diebbuk: {
@@ -49658,6 +49681,7 @@ blobbosmechelectric: {
 		heightm: 2.1,
 		weightkg: 165.7,
 		color: "White",
+		prevo : "Dewgong",
 		eggGroups: ["Water1", "Field"],
 	},
 	introll: {
@@ -49848,6 +49872,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 10.0,
 		color: "Black",
+		prevo : "Unown",
 		eggGroups: ["Undiscovered"],
 	},
 	maghat: {
@@ -49895,7 +49920,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 6.5,
 		color: "Brown",
-		evos : ["Mettabot", "Asgoat", "Floweyr", "Toriegoat", "Undyrate", "Skeleton", "Characide", "Papyrousle"],
+		evos : ["Floweyr", "Skeleton", "Asgoat", "Toriegoat", "Undyrate", "Mettabot", "Characide", "Papyrousle"],
 		eggGroups: ["Monster"],
 	},
 	undyrate: {
@@ -49955,7 +49980,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 0.5,
 		color: "Black",
-		evos : ["Byaklight", "Huntorror"],
+		evos : ["Huntorror", "Byaklight"],
 		eggGroups: ["Fairy", "Monster"],
 	},
 	huntorror: {
@@ -50543,7 +50568,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 7.5,
 		color: "Pink",
-		evos : ["Lycanmoon", "Lycanmars"],
+		evos : ["Lycanmars", "Lycanmoon"],
 		eggGroups: ["Field"],
 	},
 	lycanmoon: {
@@ -50603,6 +50628,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 4.0,
 		color: "Purple",
+		prevo : "Shellder",
 		eggGroups: ["Water3"],
 	},
 	dedfishe: {
@@ -50710,7 +50736,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 10.2,
 		color: "Black",
-		evos : ["Clownask", "Ayymask", "Lagoonask", "Zombmask", "Mummyask", "Demask", "Vampask", "Jackask", "Wolfmansk", "Phantmask", "Invisimask", "Skullask", "Witchise"],
+		evos : ["Lagoonask", "Witchise", "Mummyask", "Vampask", "Skullask", "Zombmask", "Wolfmansk", "Jackask", "Clownask", "Invisimask", "Ayymask", "Demask", "Phantmask"],
 		eggGroups: ["Humanlike", "Fairy"],
 	},
 	phantmask: {
@@ -50816,6 +50842,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	seapi: {
@@ -51211,7 +51238,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 4.2,
 		color: "Yellow",
-		evos : ["Aperrserker", "Apersian", "Gameowth"],
+		evos : ["Gameowth", "Aperrserker", "Apersian"],
 		eggGroups: ["Field"],
 	},
 	apersian: {
@@ -51236,6 +51263,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 120.0,
 		color: "Yellow",
+		prevo : "Exeggcute",
 		eggGroups: ["Grass"],
 	},
 	agrimer: {
@@ -51271,6 +51299,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 45.0,
 		color: "Brown",
+		prevo : "Cubone",
 		eggGroups: ["Monster"],
 	},
 	aparas: {
@@ -51415,6 +51444,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 30.0,
 		color: "Yellow",
+		prevo : "Pikachu",
 		eggGroups: ["Field", "Fairy"],
 	},
 	apoochyena: {
@@ -51620,6 +51650,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	sloggoth: {
@@ -51677,6 +51708,7 @@ blobbosmechelectric: {
 		heightm: 2.5,
 		weightkg: 220.0,
 		color: "Blue",
+		prevo : "Lapras",
 		eggGroups: ["Monster", "Water1"],
 	},
 	pmagikarp: {
@@ -52041,6 +52073,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 125.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	zephyreon: {
@@ -52052,6 +52085,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 10.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	champeon: {
@@ -52063,6 +52097,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 10.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	phanteon: {
@@ -52074,6 +52109,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 10.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	asableye: {
@@ -52197,7 +52233,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 6.6,
 		color: "White",
-		evos : ["Sylphind", "Lampeath", "Naiqua", "Aulpriland", "Dryasin"],
+		evos : ["Sylphind", "Naiqua", "Dryasin", "Lampeath", "Aulpriland"],
 		eggGroups: ["Humanlike", "Fairy"],
 	},
 	dryasin: {
@@ -52389,7 +52425,7 @@ blobbosmechelectric: {
 		weightkg: 3.3,
 		color: "Pink",
 		prevo : "Nout",
-		evos : ["Treblout", "Sonout", "Lonout"],
+		evos : ["Sonout", "Treblout", "Lonout"],
 		eggGroups: ["Amorphous"],
 	},
 	sonout: {
@@ -52644,7 +52680,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 6.5,
 		color: "Brown",
-		evos : ["Bishess", "Chevak", "Rookower", "Kingo", "Queeness"],
+		evos : ["Queeness", "Kingo", "Rookower", "Chevak", "Bishess"],
 		eggGroups: ["Field"],
 	},
 	rookower: {
@@ -52729,7 +52765,7 @@ blobbosmechelectric: {
 		weightkg: 0.1,
 		color: "Blue",
 		prevo : "Bubblet",
-		evos : ["Elebubble", "Burble", "Cobrubble", "Drabon", "Turble", "Leobble"],
+		evos : ["Drabon", "Elebubble", "Burble", "Cobrubble", "Turble", "Leobble"],
 		eggGroups: ["Water1"],
 	},
 	cobrubble: {
@@ -52863,7 +52899,7 @@ blobbosmechelectric: {
 		weightkg: 15.4,
 		color: "Blue",
 		prevo : "Tomatea",
-		evos : ["Pepperella", "Bause"],
+		evos : ["Bause", "Pepperella"],
 		eggGroups: ["Grass"],
 	},
 	pepperella: {
@@ -52899,7 +52935,7 @@ blobbosmechelectric: {
 		heightm: 0.1,
 		weightkg: 0.4,
 		color: "Purple",
-		evos : ["Frwind", "Sunnound", "Clounight", "Acidoud", "Rainoud", "Clawnd", "Thundoud", "Clwister"],
+		evos : ["Frwind", "Sunnound", "Rainoud", "Clwister", "Clounight", "Acidoud", "Thundoud", "Clawnd"],
 		eggGroups: ["Amorphous", "Mineral"],
 	},
 	rainoud: {
@@ -53080,7 +53116,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 8.5,
 		color: "Gray",
-		evos : ["Ufolien", "Ufoear"],
+		evos : ["Ufoear", "Ufolien"],
 		eggGroups: ["Mineral"],
 	},
 	ufolien: {
@@ -53161,7 +53197,7 @@ blobbosmechelectric: {
 		heightm: 0.1,
 		weightkg: 1.4,
 		color: "Purple",
-		evos : ["Prishard", "Flashard", "Phanshard", "Storshard"],
+		evos : ["Phanshard", "Storshard", "Prishard", "Flashard"],
 		eggGroups: ["Amorphous", "Mineral"],
 	},
 	flashard: {
@@ -53315,7 +53351,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 0.1,
 		color: "Purple",
-		evos : ["Dardra", "Lumix", "Lidra", "Shadrix"],
+		evos : ["Lumix", "Shadrix", "Lidra", "Dardra"],
 		eggGroups: ["Amorphous"],
 	},
 	lumix: {
@@ -53573,7 +53609,7 @@ blobbosmechelectric: {
 		heightm: 0.1,
 		weightkg: 0.4,
 		color: "Purple",
-		evos : ["Verius", "Viroison", "Feaverus", "Snoozerus", "Shockerus", "Cuberus"],
+		evos : ["Verius", "Viroison", "Cuberus", "Shockerus", "Snoozerus", "Feaverus"],
 		eggGroups: ["Amorphous", "Mineral"],
 	},
 	verius: {
@@ -53694,7 +53730,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 6.9,
 		color: "Purple",
-		evos : ["Comfstrictor", "Serfric"],
+		evos : ["Serfric", "Comfstrictor"],
 		eggGroups: ["Field", "Dragon"],
 	},
 	serfric: {
@@ -54397,6 +54433,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 12.0,
 		color: "Gray",
+		prevo : "Remoraid",
 		evos : ["Boctillery"],
 		eggGroups: ["Water1", "Water2"],
 	},
@@ -54432,6 +54469,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 4.0,
 		color: "Purple",
+		prevo : "Ditto",
 		eggGroups: ["Ditto"],
 	},
 	balistagon: {
@@ -54614,6 +54652,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Leafeon",
 		eggGroups: ["Field"],
 	},
 	trifox: {
@@ -54649,6 +54688,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 128.6,
 		color: "Blue",
+		prevo : "Tangela",
 		eggGroups: ["Grass"],
 	},
 	rayleep: {
@@ -54671,6 +54711,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 3.9,
 		color: "Gray",
+		prevo : "Qwilfish",
 		eggGroups: ["Water2"],
 	},
 	apichu: {
@@ -54682,6 +54723,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 2.0,
 		color: "Yellow",
+		prevo : "Pichu",
 		evos : ["Pikachu"],
 		eggGroups: ["Undiscovered"],
 	},
@@ -54730,7 +54772,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 15.0,
 		color: "Red",
-		evos : ["Anchorage", "Grotess", "Molaee"],
+		evos : ["Grotess", "Molaee", "Anchorage"],
 		eggGroups: ["Water2"],
 	},
 	anchorage: {
@@ -54883,6 +54925,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 35.6,
 		color: "Red",
+		prevo : "Ledyba",
 		eggGroups: ["Bug"],
 	},
 	minicorn: {
@@ -54906,6 +54949,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 27.0,
 		color: "Black",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	turbann: {
@@ -54917,6 +54961,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 4.0,
 		color: "Purple",
+		prevo : "Shellder",
 		eggGroups: ["Water3"],
 	},
 	grimey: {
@@ -55061,6 +55106,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 5.8,
 		color: "Green",
+		prevo : "Gloom",
 		eggGroups: ["Grass"],
 	},
 	belmitt: {
@@ -55072,6 +55118,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 15.5,
 		color: "Green",
+		prevo : "Weepinbell",
 		eggGroups: ["Grass"],
 	},
 	bomseel: {
@@ -55095,6 +55142,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 16.0,
 		color: "Red",
+		prevo : "Delibird",
 		eggGroups: ["Water1", "Field"],
 	},
 	tigrette: {
@@ -55131,6 +55179,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 15.0,
 		color: "Brown",
+		prevo : "Farfetchd",
 		eggGroups: ["Flying", "Field"],
 	},
 	kurstraw: {
@@ -55166,6 +55215,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 2.1,
 		color: "Black",
+		prevo : "Murkrow",
 		eggGroups: ["Flying"],
 	},
 	happi: {
@@ -55177,6 +55227,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 46.8,
 		color: "Pink",
+		prevo : "Chansey",
 		eggGroups: ["Fairy"],
 	},
 	scizors: {
@@ -55188,6 +55239,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 118.0,
 		color: "Red",
+		prevo : "Scyther",
 		eggGroups: ["Bug"],
 	},
 	plux: {
@@ -55199,6 +55251,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 55.0,
 		color: "Brown",
+		prevo : "Pinsir",
 		eggGroups: ["Bug"],
 	},
 	wolfman: {
@@ -55234,6 +55287,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 32.5,
 		color: "Red",
+		prevo : "Porygon",
 		eggGroups: ["Mineral"],
 	},
 	likk: {
@@ -55245,6 +55299,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 140.0,
 		color: "Pink",
+		prevo : "Lickitung",
 		eggGroups: ["Monster"],
 	},
 	bkingdra: {
@@ -55256,6 +55311,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 152.0,
 		color: "Blue",
+		prevo : "Seadra",
 		eggGroups: ["Water1", "Dragon"],
 	},
 	rai: {
@@ -55300,6 +55356,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 28.0,
 		color: "Black",
+		prevo : "Sneasel",
 		eggGroups: ["Field"],
 	},
 	tael: {
@@ -55311,6 +55368,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 11.5,
 		color: "Purple",
+		prevo : "Aipom",
 		eggGroups: ["Field"],
 	},
 	pikablu: {
@@ -55322,6 +55380,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 8.5,
 		color: "Blue",
+		prevo : "Marill",
 		eggGroups: ["Water1", "Fairy"],
 	},
 	bhooh: {
@@ -55355,7 +55414,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 75.0,
 		color: "Blue",
-		prevo : "Bwooper",
+		prevo : "Wooperbwooper",
 		eggGroups: ["Water1", "Field"],
 	},
 	sunnee: {
@@ -55367,7 +55426,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 8.5,
 		color: "Yellow",
-		prevo : "Sunsproutbsunkern",
+		prevo : "Sunkernsunsproutbsunkern",
 		eggGroups: ["Grass"],
 	},
 	shrinae: {
@@ -55390,6 +55449,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 12.4,
 		color: "Blue",
+		prevo : "Poliwag",
 		evos : ["Nyosuka"],
 		eggGroups: ["Water1"],
 	},
@@ -55414,6 +55474,7 @@ blobbosmechelectric: {
 		heightm: 4.0,
 		weightkg: 16.5,
 		color: "Blue",
+		prevo : "Dratinidragonair",
 		eggGroups: ["Water1", "Dragon"],
 	},
 	augumon: {
@@ -55426,7 +55487,7 @@ blobbosmechelectric: {
 		weightkg: 16.5,
 		color: "Blue",
 		prevo : "Koromon",
-		evos : ["Hitleragumon", "Tyrannomon", "Stoyagumon", "Snowagumon", "Greymon", "Toyagumon"],
+		evos : ["Hitleragumon", "Toyagumon", "Tyrannomon", "Stoyagumon", "Greymon", "Snowagumon"],
 		eggGroups: ["Mineral", "Dragon"],
 	},
 	greymon: {
@@ -55439,7 +55500,7 @@ blobbosmechelectric: {
 		weightkg: 16.5,
 		color: "Blue",
 		prevo : "Augumon",
-		evos : ["Metalgreymon", "Skullgreymon", "Metalgreymonv"],
+		evos : ["Skullgreymon", "Metalgreymonv", "Metalgreymon"],
 		eggGroups: ["Mineral", "Dragon"],
 	},
 	devull: {
@@ -55451,6 +55512,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 10.8,
 		color: "Black",
+		prevo : "Houndour",
 		evos : ["Bhoundoom"],
 		eggGroups: ["Field"],
 	},
@@ -55475,6 +55537,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 26.5,
 		color: "Purple",
+		prevo : "Espeon",
 		eggGroups: ["Field"],
 	},
 	urchall: {
@@ -55510,6 +55573,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 65.5,
 		color: "Pink",
+		prevo : "Lickitung",
 		eggGroups: ["Monster"],
 	},
 	yoshi: {
@@ -55521,6 +55585,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 65.5,
 		color: "Pink",
+		prevo : "Dratini",
 		eggGroups: ["Monster"],
 	},
 	ahole: {
@@ -55593,7 +55658,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 1.5,
 		color: "White",
-		evos : ["Eggotto", "Friedack"],
+		evos : ["Friedack", "Eggotto"],
 		eggGroups: ["Undiscovered"],
 	},
 	eggotto: {
@@ -55640,6 +55705,7 @@ blobbosmechelectric: {
 		heightm: 14.5,
 		weightkg: 750.0,
 		color: "Blue",
+		prevo : "Wailmer",
 		eggGroups: ["Field", "Water2"],
 	},
 	cbulbasaur: {
@@ -56062,7 +56128,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 120.0,
 		color: "Gray",
-		prevo : "Hurhydon",
+		prevo : "Rhydonhurhydon",
 		eggGroups: ["Monster", "Field"],
 	},
 	bspearow: {
@@ -56074,6 +56140,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 2.0,
 		color: "Brown",
+		prevo : "Spearow",
 		eggGroups: ["Flying"],
 	},
 	bclefairy: {
@@ -56085,6 +56152,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 7.5,
 		color: "Pink",
+		prevo : "Clefairy",
 		eggGroups: ["Fairy"],
 	},
 	bvenusaur: {
@@ -56096,6 +56164,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 100.0,
 		color: "Green",
+		prevo : "Ivysaur",
 		eggGroups: ["Monster", "Grass"],
 	},
 	bseel: {
@@ -56107,6 +56176,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 90.0,
 		color: "White",
+		prevo : "Seel",
 		eggGroups: ["Water1", "Field"],
 	},
 	arrowa: {
@@ -56162,6 +56232,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 0.1,
 		color: "Purple",
+		prevo : "Haunter",
 		eggGroups: ["Amorphous"],
 	},
 	hellraiser: {
@@ -56173,6 +56244,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 0.1,
 		color: "Purple",
+		prevo : "Haunter",
 		eggGroups: ["Amorphous"],
 	},
 	icepick: {
@@ -56184,6 +56256,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 56.0,
 		color: "Green",
+		prevo : "Scyther",
 		eggGroups: ["Bug"],
 	},
 	flamefetchd: {
@@ -56195,6 +56268,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 15.0,
 		color: "Brown",
+		prevo : "Farfetchd",
 		eggGroups: ["Flying", "Field"],
 	},
 	vshuckle: {
@@ -56217,6 +56291,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 61.5,
 		color: "Yellow",
+		prevo : "Flaaffy",
 		eggGroups: ["Monster", "Field"],
 	},
 	slowloss: {
@@ -56228,6 +56303,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 36.0,
 		color: "Pink",
+		prevo : "Slowpoke",
 		eggGroups: ["Monster", "Water1"],
 	},
 	fracture: {
@@ -56239,6 +56315,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 45.0,
 		color: "Brown",
+		prevo : "Marowak",
 		eggGroups: ["Monster"],
 	},
 	pikared: {
@@ -56250,6 +56327,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 6.0,
 		color: "Yellow",
+		prevo : "Pikachu",
 		eggGroups: ["Field", "Fairy"],
 	},
 	feliflame: {
@@ -56261,6 +56339,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 32.0,
 		color: "Yellow",
+		prevo : "Meowth",
 		eggGroups: ["Field"],
 	},
 	raticlaw: {
@@ -56272,6 +56351,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 18.5,
 		color: "Brown",
+		prevo : "Raticate",
 		eggGroups: ["Field"],
 	},
 	clegnyana: {
@@ -56283,6 +56363,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 34.6,
 		color: "Pink",
+		prevo : "Chansey",
 		eggGroups: ["Fairy"],
 	},
 	pikabud: {
@@ -56294,6 +56375,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 6.0,
 		color: "Yellow",
+		prevo : "Pikachu",
 		eggGroups: ["Field", "Fairy"],
 	},
 	alenkar: {
@@ -56305,6 +56387,7 @@ blobbosmechelectric: {
 		heightm: 2.5,
 		weightkg: 0.1,
 		color: "Brown",
+		prevo : "Kadabra",
 		eggGroups: ["Humanlike"],
 	},
 	dreamaster: {
@@ -56316,6 +56399,7 @@ blobbosmechelectric: {
 		heightm: 2.6,
 		weightkg: 85.6,
 		color: "Yellow",
+		prevo : "Hypno",
 		eggGroups: ["Humanlike"],
 	},
 	fletchice: {
@@ -57092,7 +57176,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 16.8,
 		color: "Gray",
-		evos : ["Artania", "Apollolar", "Merquick", "Venusess", "Marsarrior"],
+		evos : ["Marsarrior", "Merquick", "Venusess", "Apollolar", "Artania"],
 		eggGroups: ["Fairy", "Humanlike"],
 	},
 	marsarrior: {
@@ -57139,6 +57223,7 @@ blobbosmechelectric: {
 		heightm: 6.5,
 		weightkg: 235.0,
 		color: "Blue",
+		prevo : "Magikarp",
 		eggGroups: ["Water2", "Dragon"],
 	},
 	babirys: {
@@ -57339,7 +57424,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 2.1,
 		color: "White",
-		evos : ["Winpane", "Winblow", "Peekindow"],
+		evos : ["Peekindow", "Winpane", "Winblow"],
 		eggGroups: ["Mineral"],
 	},
 	winblow: {
@@ -57900,7 +57985,7 @@ blobbosmechelectric: {
 		weightkg: 8.5,
 		color: "Gray",
 		prevo : "Supaninteno",
-		evos : ["Threediesh", "Wiilly"],
+		evos : ["Wiilly", "Threediesh"],
 		eggGroups: ["Mineral"],
 	},
 	wiilly: {
@@ -58116,7 +58201,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 33.5,
 		color: "Blue",
-		evos : ["Electrain", "Strain", "Shinkantrain"],
+		evos : ["Shinkantrain", "Strain", "Electrain"],
 		eggGroups: ["Field"],
 	},
 	strain: {
@@ -58175,6 +58260,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 69,
 		color: "Brown",
+		prevo : "Staryu",
 		eggGroups: ["Water3"],
 	},
 	chiyailor: {
@@ -58197,6 +58283,7 @@ blobbosmechelectric: {
 		heightm: 4.2,
 		weightkg: 1135.5,
 		color: "White",
+		prevo : "Abomasnow",
 		eggGroups: ["Monster", "Grass"],
 	},
 	mmawile: {
@@ -58208,6 +58295,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 21.5,
 		color: "Black",
+		prevo : "Mawile",
 		eggGroups: ["Field", "Fairy"],
 	},
 	aabsol: {
@@ -58219,6 +58307,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 47.0,
 		color: "White",
+		prevo : "Absol",
 		eggGroups: ["Field"],
 	},
 	bbanette: {
@@ -58230,6 +58319,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 12.5,
 		color: "Black",
+		prevo : "Banette",
 		eggGroups: ["Amorphous"],
 	},
 	rumiarkness: {
@@ -58426,7 +58516,7 @@ blobbosmechelectric: {
 		heightm: 3.2,
 		weightkg: 465.5,
 		color: "Pink",
-		evos : ["Amiibobowser", "Meowser", "Mechabowserstatue", "Bowser Statue", "Retro Bowser", "Kart Bowser", "Megadragonbowser", "Skylanderbowser", "Bowsette", "Bowletta", "Drbowser", "Bowser Koobala", "Paperbowser", "Metal Bowser", "Dry Bowser", "Cakebowser", "Dark Bowser", "Fury Bowser", "Shrowser"],
+		evos : ["Bowser Statue", "Paperbowser", "Fury Bowser", "Megadragonbowser", "Drbowser", "Bowsette", "Kart Bowser", "Bowletta", "Mechabowserstatue", "Dark Bowser", "Bowser Koobala", "Dry Bowser", "Amiibobowser", "Metal Bowser", "Retro Bowser", "Cakebowser", "Shrowser", "Meowser", "Skylanderbowser"],
 		eggGroups: ["Monster"],
 	},
 	risatsuki: {
@@ -58493,6 +58583,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 36.5,
 		color: "Pink",
+		prevo : "Porygon",
 		eggGroups: ["Mineral"],
 	},
 	tewiabbit: {
@@ -58988,7 +59079,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 200.6,
 		color: "Red",
-		prevo : "Huelectrode",
+		prevo : "Electrodehuelectrode",
 		eggGroups: ["Mineral"],
 	},
 	gamble: {
@@ -59000,6 +59091,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 34.6,
 		color: "Pink",
+		prevo : "Chansey",
 		eggGroups: ["Fairy"],
 	},
 	pinsire: {
@@ -59011,6 +59103,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 55.0,
 		color: "Brown",
+		prevo : "Pinsir",
 		eggGroups: ["Bug"],
 	},
 	cliffracer: {
@@ -59374,6 +59467,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 10.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	skullask: {
@@ -59453,6 +59547,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 11.0,
 		color: "Purple",
+		prevo : "Sableye",
 		eggGroups: ["Humanlike"],
 	},
 	msteelix: {
@@ -59464,6 +59559,7 @@ blobbosmechelectric: {
 		heightm: 9.2,
 		weightkg: 400.0,
 		color: "Gray",
+		prevo : "Steelix",
 		eggGroups: ["Mineral"],
 	},
 	mcsteelix: {
@@ -59694,6 +59790,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 2.0,
 		color: "Brown",
+		prevo : "Spearow",
 		eggGroups: ["Flying"],
 	},
 	laprince: {
@@ -59705,6 +59802,7 @@ blobbosmechelectric: {
 		heightm: 12.5,
 		weightkg: 1220.0,
 		color: "Blue",
+		prevo : "Lapras",
 		eggGroups: ["Monster", "Water1"],
 	},
 	firefree: {
@@ -59716,6 +59814,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 32.0,
 		color: "White",
+		prevo : "Butterfree",
 		eggGroups: ["Bug"],
 	},
 	pegazeus: {
@@ -59727,6 +59826,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 95.0,
 		color: "Yellow",
+		prevo : "Ponyta",
 		eggGroups: ["Field"],
 	},
 	shockra: {
@@ -60026,6 +60126,7 @@ blobbosmechelectric: {
 		heightm: 6.5,
 		weightkg: 235.0,
 		color: "Blue",
+		prevo : "Magikarp",
 		eggGroups: ["Water3", "Bug"],
 	},
 	corruptedsol: {
@@ -60060,6 +60161,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 12.5,
 		color: "Black",
+		prevo : "Shuppet",
 		eggGroups: ["Amorphous"],
 	},
 	indianelephant: {
@@ -60139,6 +60241,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 30.0,
 		color: "Yellow",
+		prevo : "Pikachu",
 		eggGroups: ["Field", "Fairy"],
 	},
 	mordrayal: {
@@ -60319,6 +60422,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 76.6,
 		color: "Blue",
+		prevo : "Psyduck",
 		evos : ["Golduck"],
 		eggGroups: ["Water1", "Field"],
 	},
@@ -60331,6 +60435,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 45.0,
 		color: "Brown",
+		prevo : "Marowak",
 		eggGroups: ["Monster"],
 	},
 	buu: {
@@ -60436,6 +60541,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 22.5,
 		color: "Blue",
+		prevo : "Wartortle",
 		eggGroups: ["Monster", "Water1"],
 	},
 	blastyke: {
@@ -60447,6 +60553,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 99.5,
 		color: "Blue",
+		prevo : "Squirtle",
 		eggGroups: ["Monster", "Water1"],
 	},
 	sumorog: {
@@ -60996,6 +61103,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 10.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field", "Flying"],
 	},
 	brynhildcer: {
@@ -61040,6 +61148,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 27.0,
 		color: "Black",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	elechair: {
@@ -61063,6 +61172,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 27.0,
 		color: "Black",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	chaneller: {
@@ -61085,6 +61195,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 54.0,
 		color: "Blue",
+		prevo : "Lucario",
 		eggGroups: ["Field", "Humanlike"],
 	},
 	mmanectric: {
@@ -61096,6 +61207,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 40.2,
 		color: "Yellow",
+		prevo : "Manectric",
 		eggGroups: ["Field"],
 	},
 	mslowbro: {
@@ -61107,6 +61219,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 78.5,
 		color: "Pink",
+		prevo : "Slowbro",
 		eggGroups: ["Monster", "Water1"],
 	},
 	mgyarados: {
@@ -61118,6 +61231,7 @@ blobbosmechelectric: {
 		heightm: 6.5,
 		weightkg: 235.0,
 		color: "Blue",
+		prevo : "Gyarados",
 		eggGroups: ["Water2", "Dragon"],
 	},
 	mscizor: {
@@ -61129,6 +61243,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 118.0,
 		color: "Red",
+		prevo : "Scizor",
 		eggGroups: ["Bug"],
 	},
 	mglalie: {
@@ -61140,6 +61255,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 256.5,
 		color: "Gray",
+		prevo : "Glalie",
 		eggGroups: ["Fairy", "Mineral"],
 	},
 	mlopunny: {
@@ -61151,6 +61267,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 33.3,
 		color: "Brown",
+		prevo : "Lopunny",
 		eggGroups: ["Field", "Humanlike"],
 	},
 	snapchost: {
@@ -61174,6 +61291,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 27.0,
 		color: "Black",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	alteraber: {
@@ -61486,7 +61604,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 41.0,
 		color: "Red",
-		evos : ["Archongel", "Aeongel"],
+		evos : ["Aeongel", "Archongel"],
 		eggGroups: ["Humanlike", "Monster"],
 	},
 	cakeross: {
@@ -61577,6 +61695,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 18.5,
 		color: "Brown",
+		prevo : "Rattata",
 		evos : ["Praticlaw"],
 		eggGroups: ["Field"],
 	},
@@ -61589,6 +61708,7 @@ blobbosmechelectric: {
 		heightm: 2.1,
 		weightkg: 460.0,
 		color: "Black",
+		prevo : "Munchlax",
 		eggGroups: ["Monster"],
 	},
 	cradisk: {
@@ -61622,6 +61742,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 34.6,
 		color: "Pink",
+		prevo : "Chansey",
 		eggGroups: ["Fairy"],
 	},
 	cencyclodia: {
@@ -61737,7 +61858,7 @@ blobbosmechelectric: {
 		heightm: 2.3,
 		weightkg: 2.1,
 		color: "White",
-		evos : ["Terraol", "Aquariuol"],
+		evos : ["Aquariuol", "Terraol"],
 		eggGroups: ["Mineral"],
 	},
 	aquariuol: {
@@ -61785,6 +61906,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 33.5,
 		color: "Red",
+		prevo : "Spinarak",
 		eggGroups: ["Bug"],
 	},
 	tuberm: {
@@ -62050,7 +62172,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 21.0,
 		color: "Purple",
-		evos : ["Overock", "Blastrock", "Chillrock"],
+		evos : ["Blastrock", "Chillrock", "Overock"],
 		eggGroups: ["Mineral"],
 	},
 	chillrock: {
@@ -62330,6 +62452,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 80.0,
 		color: "Purple",
+		prevo : "Staryu",
 		eggGroups: ["Water3"],
 	},
 	ghostly: {
@@ -62352,6 +62475,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 56.0,
 		color: "Green",
+		prevo : "Scyther",
 		eggGroups: ["Bug"],
 	},
 	asmoochum: {
@@ -62410,7 +62534,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 6.5,
 		color: "Brown",
-		evos : ["Heartlenine", "Unlion", "Nobotile", "Royickish", "Dreagamorph"],
+		evos : ["Nobotile", "Dreagamorph", "Unlion", "Heartlenine", "Royickish"],
 		eggGroups: ["Field"],
 	},
 	heartlenine: {
@@ -62507,7 +62631,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 1.2,
 		color: "Red",
-		evos : ["Pengemperor", "Albinguin"],
+		evos : ["Albinguin", "Pengemperor"],
 		eggGroups: ["Water1", "Flying"],
 	},
 	pengemperor: {
@@ -62568,7 +62692,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 9.5,
 		color: "Purple",
-		prevo : "Wkoffing",
+		prevo : "Koffingwkoffing",
 		eggGroups: ["Amorphous"],
 	},
 	mistaibahx: {
@@ -62721,6 +62845,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 29.0,
 		color: "Blue",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	volcaneon: {
@@ -62732,6 +62857,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	timberreon: {
@@ -62743,6 +62869,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	sphealedge: {
@@ -62861,6 +62988,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	unownking: {
@@ -62918,7 +63046,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 5.5,
 		color: "Brown",
-		evos : ["Domineko", "Torappu", "Mammarina", "Lustubust", "Wyrmaiden", "Mylph", "Youkawaii", "Gothot", "Elsnow"],
+		evos : ["Elsnow", "Youkawaii", "Mylph", "Domineko", "Mammarina", "Torappu", "Gothot", "Lustubust", "Wyrmaiden"],
 		eggGroups: ["Humanlike", "Fairy"],
 	},
 	mylph: {
@@ -62942,7 +63070,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 0.1,
 		color: "Gray",
-		evos : ["Amigoggoth", "Migoggoth"],
+		evos : ["Migoggoth", "Amigoggoth"],
 		eggGroups: ["Amorphous"],
 	},
 	migoggoth: {
@@ -63119,7 +63247,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 9.0,
 		color: "Blue",
-		evos : ["Steamnie", "Stweams"],
+		evos : ["Stweams", "Steamnie"],
 		eggGroups: ["Amorphous", "Water1"],
 	},
 	stweams: {
@@ -63213,6 +63341,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	himster: {
@@ -63415,7 +63544,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 16.5,
 		color: "Brown",
-		evos : ["Prinsiel", "Jestevil", "Karmris", "Susully"],
+		evos : ["Prinsiel", "Karmris", "Jestevil", "Susully"],
 		eggGroups: ["Monster"],
 	},
 	sweetergeist: {
@@ -63606,7 +63735,7 @@ blobbosmechelectric: {
 		weightkg: 22.0,
 		color: "White",
 		prevo : "Necroli",
-		evos : ["Swimnecrolilith", "Necrolilith"],
+		evos : ["Necrolilith", "Swimnecrolilith"],
 		eggGroups: ["Amorphous"],
 	},
 	necrolilith: {
@@ -63712,7 +63841,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 1.5,
 		color: "White",
-		evos : ["Chanoken", "Chanarang"],
+		evos : ["Chanarang", "Chanoken"],
 		eggGroups: ["Undiscovered"],
 	},
 	chanarang: {
@@ -63820,6 +63949,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 4.0,
 		color: "Green",
+		prevo : "Bellsprout",
 		eggGroups: ["Grass"],
 	},
 	mpikachu: {
@@ -63831,6 +63961,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 30.0,
 		color: "Yellow",
+		prevo : "Pikachu",
 		eggGroups: ["Field", "Fairy"],
 	},
 	melectrode: {
@@ -63842,7 +63973,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 66.6,
 		color: "Red",
-		prevo : "Huelectrode",
+		prevo : "Electrodehuelectrode",
 		eggGroups: ["Mineral"],
 	},
 	mjynx: {
@@ -63854,7 +63985,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 40.6,
 		color: "Red",
-		prevo : "Hujynx",
+		prevo : "Jynxhujynx",
 		eggGroups: ["Humanlike"],
 	},
 	majynx: {
@@ -63878,6 +64009,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 33.5,
 		color: "Red",
+		prevo : "Ariados",
 		eggGroups: ["Bug"],
 	},
 	mdelcatty: {
@@ -63889,6 +64021,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 32.6,
 		color: "Purple",
+		prevo : "Delcatty",
 		eggGroups: ["Field", "Fairy"],
 	},
 	msunflora: {
@@ -63900,6 +64033,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 8.5,
 		color: "Yellow",
+		prevo : "Sunflora",
 		eggGroups: ["Grass"],
 	},
 	mcorsola: {
@@ -63911,6 +64045,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 5.0,
 		color: "Pink",
+		prevo : "Corsola",
 		eggGroups: ["Water1", "Water3"],
 	},
 	delidelibird: {
@@ -63922,6 +64057,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 16.0,
 		color: "Red",
+		prevo : "Delibird",
 		eggGroups: ["Water1", "Field"],
 	},
 	moctillery: {
@@ -63933,6 +64069,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 28.5,
 		color: "Red",
+		prevo : "Octillery",
 		eggGroups: ["Water1", "Water2"],
 	},
 	mdonphan: {
@@ -63944,6 +64081,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 120.0,
 		color: "Gray",
+		prevo : "Donphan",
 		eggGroups: ["Field"],
 	},
 	mstantler: {
@@ -63955,6 +64093,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 71.2,
 		color: "Brown",
+		prevo : "Stantler",
 		eggGroups: ["Field"],
 	},
 	mtorkoal: {
@@ -63966,6 +64105,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 80.4,
 		color: "Brown",
+		prevo : "Torkoal",
 		eggGroups: ["Field"],
 	},
 	mkecleon: {
@@ -63977,6 +64117,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 22.0,
 		color: "Green",
+		prevo : "Kecleon",
 		eggGroups: ["Field"],
 	},
 	mhuntail: {
@@ -63988,6 +64129,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 27.0,
 		color: "Blue",
+		prevo : "Huntail",
 		eggGroups: ["Water1"],
 	},
 	mgorebyss: {
@@ -63999,6 +64141,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 22.6,
 		color: "Pink",
+		prevo : "Gorebyss",
 		eggGroups: ["Water1"],
 	},
 	mchatot: {
@@ -64010,6 +64153,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 1.9,
 		color: "Black",
+		prevo : "Chatot",
 		eggGroups: ["Flying"],
 	},
 	mcarnivine: {
@@ -64021,6 +64165,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 27.0,
 		color: "Green",
+		prevo : "Carnivine",
 		eggGroups: ["Grass"],
 	},
 	mlumineon: {
@@ -64032,6 +64177,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 24.0,
 		color: "Blue",
+		prevo : "Lumineon",
 		eggGroups: ["Water2"],
 	},
 	mswoobat: {
@@ -64043,6 +64189,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 10.5,
 		color: "Blue",
+		prevo : "Swoobat",
 		eggGroups: ["Flying", "Field"],
 	},
 	mheliolisk: {
@@ -64066,6 +64213,7 @@ blobbosmechelectric: {
 		heightm: 4.8,
 		weightkg: 115.0,
 		color: "Brown",
+		prevo : "Farfetchd",
 		eggGroups: ["Flying", "Field"],
 	},
 	mplusle: {
@@ -64077,6 +64225,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 4.2,
 		color: "Yellow",
+		prevo : "Plusle",
 		eggGroups: ["Fairy"],
 	},
 	mminun: {
@@ -64088,6 +64237,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 4.2,
 		color: "Yellow",
+		prevo : "Minun",
 		eggGroups: ["Fairy"],
 	},
 	voltcube: {
@@ -64099,6 +64249,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 10.4,
 		color: "Red",
+		prevo : "Voltorb",
 		eggGroups: ["Mineral"],
 	},
 	daolangle: {
@@ -64121,6 +64272,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 23.6,
 		color: "Blue",
+		prevo : "Whiscash",
 		eggGroups: ["Water2"],
 	},
 	mrelicanth: {
@@ -64132,6 +64284,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 23.4,
 		color: "Gray",
+		prevo : "Relicanth",
 		eggGroups: ["Water1", "Water2"],
 	},
 	momastar: {
@@ -64143,7 +64296,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 35.0,
 		color: "Blue",
-		prevo : "Huomastar",
+		prevo : "Omastarhuomastar",
 		eggGroups: ["Water1", "Water3"],
 	},
 	mkabutops: {
@@ -64155,6 +64308,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 40.5,
 		color: "Brown",
+		prevo : "Kabutops",
 		eggGroups: ["Water1", "Water3"],
 	},
 	mgarbodor: {
@@ -64166,6 +64320,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 107.3,
 		color: "Green",
+		prevo : "Garbodor",
 		eggGroups: ["Mineral"],
 	},
 	starpire: {
@@ -64236,6 +64391,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 18.7,
 		color: "Blue",
+		prevo : "Luvdisc",
 		eggGroups: ["Water2"],
 	},
 	mluvdiscy: {
@@ -64247,6 +64403,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 18.7,
 		color: "Blue",
+		prevo : "Luvdisc",
 		eggGroups: ["Water2"],
 	},
 	karmris: {
@@ -64390,6 +64547,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 155.0,
 		color: "Red",
+		prevo : "Magcargo",
 		eggGroups: ["Amorphous"],
 	},
 	drowsleep: {
@@ -64508,7 +64666,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 21.9,
 		color: "Yellow",
-		prevo : "Huninetales",
+		prevo : "Ninetaleshuninetales",
 		eggGroups: ["Field"],
 	},
 	mrapidash: {
@@ -64520,6 +64678,7 @@ blobbosmechelectric: {
 		heightm: 2.7,
 		weightkg: 125.0,
 		color: "Yellow",
+		prevo : "Rapidash",
 		eggGroups: ["Field"],
 	},
 	formspawn: {
@@ -64542,6 +64701,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 58.0,
 		color: "Red",
+		prevo : "Heatmor",
 		eggGroups: ["Field"],
 	},
 	himf: {
@@ -64564,6 +64724,7 @@ blobbosmechelectric: {
 		heightm: 2.7,
 		weightkg: 195.0,
 		color: "Yellow",
+		prevo : "Rapidash",
 		eggGroups: ["Field"],
 	},
 	tsoadggua: {
@@ -64608,7 +64769,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 155.0,
 		color: "Brown",
-		prevo : "Ionnine",
+		prevo : "Arcanineionnine",
 		eggGroups: ["Field"],
 	},
 	spooklypuff: {
@@ -64620,7 +64781,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 0.5,
 		color: "Pink",
-		prevo : "Bjigglypuff",
+		prevo : "Jigglypuffbjigglypuff",
 		eggGroups: ["Fairy", "Amorphous"],
 	},
 	stogenie: {
@@ -64656,7 +64817,7 @@ blobbosmechelectric: {
 		weightkg: 24.4,
 		color: "Pink",
 		prevo : "Ebolette",
-		evos : ["Nursebola", "Autisma"],
+		evos : ["Autisma", "Nursebola"],
 		eggGroups: ["Amorphous", "Fairy"],
 	},
 	tortaco: {
@@ -64973,7 +65134,7 @@ blobbosmechelectric: {
 		weightkg: 14.7,
 		color: "Gray",
 		prevo : "Starvipup",
-		evos : ["Hollowland", "Loyaland"],
+		evos : ["Loyaland", "Hollowland"],
 		eggGroups: ["Field"],
 	},
 	hollowland: {
@@ -65055,7 +65216,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 20.5,
 		color: "Yellow",
-		evos : ["Noocon", "Xokcon", "Cursedcon", "Crycon"],
+		evos : ["Cursedcon", "Xokcon", "Crycon", "Noocon"],
 		eggGroups: ["Amorphous"],
 	},
 	cursedcon: {
@@ -65248,6 +65409,7 @@ blobbosmechelectric: {
 		heightm: 25.4,
 		weightkg: 914.2,
 		color: "Yellow",
+		prevo : "Meowth",
 		eggGroups: ["Field"],
 	},
 	gameowth: {
@@ -65271,6 +65433,7 @@ blobbosmechelectric: {
 		heightm: 15.4,
 		weightkg: 1116.0,
 		color: "Yellow",
+		prevo : "Pikachu",
 		eggGroups: ["Field", "Fairy"],
 	},
 	geevee: {
@@ -65282,6 +65445,7 @@ blobbosmechelectric: {
 		heightm: 12.3,
 		weightkg: 816.5,
 		color: "Brown",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	galcremie: {
@@ -65329,6 +65493,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 5.0,
 		color: "Brown",
+		prevo : "Spinda",
 		eggGroups: ["Field", "Humanlike"],
 	},
 	mpyroar: {
@@ -65422,6 +65587,7 @@ blobbosmechelectric: {
 		heightm: 10.5,
 		weightkg: 112.5,
 		color: "Purple",
+		prevo : "Venonat",
 		eggGroups: ["Bug"],
 	},
 	beatoriche: {
@@ -65456,6 +65622,7 @@ blobbosmechelectric: {
 		heightm: 2.5,
 		weightkg: 33.9,
 		color: "Gray",
+		prevo : "Qwilfish",
 		eggGroups: ["Water2"],
 	},
 	navabrine: {
@@ -65467,7 +65634,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 33.9,
 		color: "Gray",
-		prevo : "Aqwilfish",
+		prevo : "Qwilfishaqwilfish",
 		evos : ["Koilrig"],
 		eggGroups: ["Water2", "Mineral"],
 	},
@@ -65492,6 +65659,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 28.5,
 		color: "Blue",
+		prevo : "Wobbuffet",
 		eggGroups: ["Amorphous"],
 	},
 	yeerby: {
@@ -65503,7 +65671,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 11.2,
 		color: "Brown",
-		evos : ["Stantler", "Noseer", "Moosid", "Psyelk", "Fabdeer", "Suprago", "Stormdler"],
+		evos : ["Suprago", "Psyelk", "Moosid", "Noseer", "Fabdeer", "Stormdler", "Stantler"],
 		eggGroups: ["Undiscovered"],
 	},
 	psyelk: {
@@ -65576,6 +65744,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 41.5,
 		color: "Yellow",
+		prevo : "Girafarig",
 		eggGroups: ["Field", "Amorphous"],
 	},
 	giradream: {
@@ -65587,6 +65756,7 @@ blobbosmechelectric: {
 		heightm: 2.5,
 		weightkg: 51.5,
 		color: "Yellow",
+		prevo : "Girafarig",
 		eggGroups: ["Field"],
 	},
 	himmagma: {
@@ -65666,7 +65836,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 33.9,
 		color: "Gray",
-		prevo : "Aqwilfish",
+		prevo : "Qwilfishaqwilfish",
 		eggGroups: ["Water2", "Mineral"],
 	},
 	mummyask: {
@@ -65738,7 +65908,7 @@ blobbosmechelectric: {
 		heightm: 0.2,
 		weightkg: 0.8,
 		color: "Brown",
-		prevo : "Nimbett",
+		prevo : "Diglettnimbett",
 		eggGroups: ["Field"],
 	},
 	egguish: {
@@ -65881,7 +66051,7 @@ blobbosmechelectric: {
 		heightm: 0.2,
 		weightkg: 6.5,
 		color: "Brown",
-		evos : ["Metalslimee", "Darlime", "Heal Slimee", "Seaslimee", "Bubble Slime", "Kingslimee"],
+		evos : ["Bubble Slime", "Seaslimee", "Kingslimee", "Metalslimee", "Darlime", "Heal Slimee"],
 		eggGroups: ["Amorphous"],
 	},
 	kingslimee: {
@@ -66014,7 +66184,7 @@ blobbosmechelectric: {
 		weightkg: 115.0,
 		color: "Brown",
 		prevo : "Rolycoly",
-		evos : ["Locoalmotive", "Coalossal"],
+		evos : ["Coalossal", "Locoalmotive"],
 		eggGroups: ["Mineral"],
 	},
 	galmeowth: {
@@ -66074,6 +66244,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 39.2,
 		color: "Green",
+		prevo : "Shroomish",
 		eggGroups: ["Fairy", "Grass"],
 	},
 	astrobunny: {
@@ -66121,7 +66292,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 54.5,
 		color: "Pink",
-		prevo : "Gmimejr",
+		prevo : "Mimejrgmimejr",
 		evos : ["Mr Rime"],
 		eggGroups: ["Humanlike"],
 	},
@@ -66506,6 +66677,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 66.6,
 		color: "Red",
+		prevo : "Voltorb",
 		eggGroups: ["Mineral"],
 	},
 	shadsquirtle: {
@@ -66539,6 +66711,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 28.0,
 		color: "Yellow",
+		prevo : "Pelipper",
 		eggGroups: ["Water1", "Flying"],
 	},
 	mpersian: {
@@ -66550,6 +66723,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 32.0,
 		color: "Yellow",
+		prevo : "Persian",
 		eggGroups: ["Field"],
 	},
 	mapersian: {
@@ -66573,7 +66747,7 @@ blobbosmechelectric: {
 		heightm: 3.5,
 		weightkg: 65.0,
 		color: "Purple",
-		prevo : "Huarbok",
+		prevo : "Arbokhuarbok",
 		eggGroups: ["Field", "Dragon"],
 	},
 	clowdpoke: {
@@ -66585,6 +66759,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 36.0,
 		color: "Pink",
+		prevo : "Slowpoke",
 		eggGroups: ["Monster", "Water1"],
 	},
 	torcano: {
@@ -66596,6 +66771,7 @@ blobbosmechelectric: {
 		heightm: 2.2,
 		weightkg: 310.0,
 		color: "Green",
+		prevo : "Turtwig",
 		eggGroups: ["Monster", "Grass"],
 	},
 	grumboar: {
@@ -66607,7 +66783,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 71.5,
 		color: "Purple",
-		prevo : "Cspoink",
+		prevo : "Spoinkcspoink",
 		eggGroups: ["Field"],
 	},
 	baidy: {
@@ -66631,6 +66807,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 31.0,
 		color: "Pink",
+		prevo : "Audino",
 		eggGroups: ["Fairy"],
 	},
 	wbaidy: {
@@ -66679,6 +66856,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 32.5,
 		color: "Brown",
+		prevo : "Sentret",
 		eggGroups: ["Field", "Mineral"],
 	},
 	taker: {
@@ -66713,6 +66891,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 41.5,
 		color: "Yellow",
+		prevo : "Girafarig",
 		eggGroups: ["Field", "Dragon"],
 	},
 	seafarig: {
@@ -66724,6 +66903,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 41.5,
 		color: "Yellow",
+		prevo : "Girafarig",
 		eggGroups: ["Field"],
 	},
 	pyooraffe: {
@@ -66735,6 +66915,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 41.5,
 		color: "Yellow",
+		prevo : "Girafarig",
 		eggGroups: ["Field"],
 	},
 	darkmare: {
@@ -66746,6 +66927,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 41.5,
 		color: "Yellow",
+		prevo : "Girafarig",
 		eggGroups: ["Field", "Amorphous"],
 	},
 	stunfish: {
@@ -66769,6 +66951,7 @@ blobbosmechelectric: {
 		heightm: 3.7,
 		weightkg: 91.0,
 		color: "Brown",
+		prevo : "Stunfisk",
 		eggGroups: ["Water1", "Amorphous"],
 	},
 	mantastorm: {
@@ -66780,6 +66963,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 11.0,
 		color: "Brown",
+		prevo : "Stunfisk",
 		eggGroups: ["Water1", "Amorphous"],
 	},
 	stuntrap: {
@@ -66851,6 +67035,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 34.6,
 		color: "Pink",
+		prevo : "Happiny",
 		evos : ["Wblissey"],
 		eggGroups: ["Fairy", "Mineral"],
 	},
@@ -66886,6 +67071,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 60.4,
 		color: "Green",
+		prevo : "Cradily",
 		eggGroups: ["Water3"],
 	},
 	marmaldo: {
@@ -66897,6 +67083,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 68.2,
 		color: "Gray",
+		prevo : "Armaldo",
 		eggGroups: ["Water3"],
 	},
 	drbowser: {
@@ -67055,7 +67242,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 1.4,
 		color: "Yellow",
-		evos : ["Pancallous", "Pancalamity"],
+		evos : ["Pancalamity", "Pancallous"],
 		eggGroups: ["Amorphous", "Mineral"],
 	},
 	pancalamity: {
@@ -67103,6 +67290,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 31.6,
 		color: "Pink",
+		prevo : "Alomomola",
 		eggGroups: ["Water1", "Water2"],
 	},
 	molashade: {
@@ -67114,6 +67302,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 31.6,
 		color: "Pink",
+		prevo : "Alomomola",
 		eggGroups: ["Water1", "Water2"],
 	},
 	wbasculin: {
@@ -67469,6 +67658,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 4.4,
 		color: "Purple",
+		prevo : "Mismagius",
 		eggGroups: ["Amorphous"],
 	},
 	toyagumon: {
@@ -67870,7 +68060,7 @@ blobbosmechelectric: {
 		weightkg: 16.5,
 		color: "Blue",
 		prevo : "Tentomon",
-		evos : ["Rmegakabuterimon", "Bmegakabuterimon"],
+		evos : ["Bmegakabuterimon", "Rmegakabuterimon"],
 		eggGroups: ["Bug"],
 	},
 	rmegakabuterimon: {
@@ -67933,7 +68123,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 120.0,
 		color: "White",
-		evos : ["Frostiseel", "Bomseel", "Shockaseel", "Gloseel", "Necroseel"],
+		evos : ["Frostiseel", "Gloseel", "Shockaseel", "Bomseel", "Necroseel"],
 		eggGroups: ["Water1", "Field"],
 	},
 	frostiseel: {
@@ -68006,7 +68196,7 @@ blobbosmechelectric: {
 		weightkg: 14.5,
 		color: "Green",
 		prevo : "Palmon",
-		evos : ["Lilymon", "Ponchomon"],
+		evos : ["Ponchomon", "Lilymon"],
 		eggGroups: ["Fairy", "Grass"],
 	},
 	lilymon: {
@@ -68104,7 +68294,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 21.0,
 		color: "Purple",
-		evos : ["Disfunbot", "Kizzeep", "Noofr", "Sheridryoid"],
+		evos : ["Sheridryoid", "Disfunbot", "Kizzeep", "Noofr"],
 		eggGroups: ["Undiscovered"],
 	},
 	disfunbot: {
@@ -68314,6 +68504,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 3.9,
 		color: "Gray",
+		prevo : "Qwilfish",
 		eggGroups: ["Water2"],
 	},
 	penguinmon: {
@@ -68351,7 +68542,7 @@ blobbosmechelectric: {
 		weightkg: 1115.2,
 		color: "Blue",
 		prevo : "Dolphmon",
-		evos : ["Marineangemon", "Neptunemon"],
+		evos : ["Neptunemon", "Marineangemon"],
 		eggGroups: ["Water1", "Field"],
 	},
 	neptunemon: {
@@ -68496,7 +68687,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 24.4,
 		color: "Pink",
-		evos : ["Rpdocbot", "Rpmeddy"],
+		evos : ["Rpmeddy", "Rpdocbot"],
 		eggGroups: ["Undiscovered"],
 	},
 	rpmeddy: {
@@ -68619,7 +68810,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 2.8,
 		color: "Purple",
-		evos : ["Wflapple", "Wappletun"],
+		evos : ["Wappletun", "Wflapple"],
 		eggGroups: ["Dragon"],
 	},
 	wflapple: {
@@ -68655,6 +68846,7 @@ blobbosmechelectric: {
 		heightm: 2.2,
 		weightkg: 92.5,
 		color: "Red",
+		prevo : "Charmeleon",
 		eggGroups: ["Monster", "Dragon"],
 	},
 	dinofur: {
@@ -69299,7 +69491,7 @@ blobbosmechelectric: {
 		weightkg: 19.0,
 		color: "Purple",
 		prevo : "Rpgidget",
-		evos : ["Rpbettyz", "Rpgranny"],
+		evos : ["Rpgranny", "Rpbettyz"],
 		eggGroups: ["Mineral", "Humanlike"],
 	},
 	rpbettyz: {
@@ -69705,7 +69897,7 @@ blobbosmechelectric: {
 		heightm: 0.1,
 		weightkg: 0.1,
 		color: "Blue",
-		evos : ["Appmcurry", "Beamcurry", "Cocomcurry", "Pastamcurry", "Tropmcurry", "Crmmcurry", "Samcurry", "Eggmcurry", "Herbmcurry", "Juicymcurry", "Mumcurry", "Rammcurry", "Slomcurry", "Richmcurry", "Burmcurry", "Potmcurry", "Cheesemcurry", "Salmcurry", "Bonmcurry", "Seamcurry", "Mcurry", "Leekmcurry", "Pacmcurry", "Frymcurry", "Breadmcurry"],
+		evos : ["Rammcurry", "Beamcurry", "Burmcurry", "Slomcurry", "Pastamcurry", "Herbmcurry", "Eggmcurry", "Seamcurry", "Cheesemcurry", "Cocomcurry", "Juicymcurry", "Pacmcurry", "Bonmcurry", "Breadmcurry", "Potmcurry", "Salmcurry", "Samcurry", "Appmcurry", "Frymcurry", "Mcurry", "Tropmcurry", "Crmmcurry", "Mumcurry", "Leekmcurry", "Richmcurry"],
 		eggGroups: ["Grass", "Amorphous"],
 	},
 	mcurry: {
@@ -69766,7 +69958,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 1.2,
 		color: "Green",
-		evos : ["Honbrosia", "Sucklaxis"],
+		evos : ["Sucklaxis", "Honbrosia"],
 		eggGroups: ["Dragon", "Grass"],
 	},
 	sucklaxis: {
@@ -69861,7 +70053,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 38.0,
 		color: "Brown",
-		prevo : "Fearolt",
+		prevo : "Fearowfearolt",
 		eggGroups: ["Flying"],
 	},
 	gomamon: {
@@ -69934,6 +70126,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 300.0,
 		color: "Brown",
+		prevo : "Graveler",
 		eggGroups: ["Mineral"],
 	},
 	wbarboach: {
@@ -70294,7 +70487,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 6.5,
 		color: "Blue",
-		evos : ["Blackagumon", "Snowgoblimon", "Goblimon", "Shamanmon"],
+		evos : ["Goblimon", "Blackagumon", "Shamanmon", "Snowgoblimon"],
 		eggGroups: ["Undiscovered"],
 	},
 	goblimon: {
@@ -70307,7 +70500,7 @@ blobbosmechelectric: {
 		weightkg: 16.5,
 		color: "Blue",
 		prevo : "Pagumon",
-		evos : ["Fugamon", "Hyogamon", "Ogremon"],
+		evos : ["Ogremon", "Hyogamon", "Fugamon"],
 		eggGroups: ["Fairy"],
 	},
 	ogremon: {
@@ -70357,7 +70550,7 @@ blobbosmechelectric: {
 		weightkg: 116.5,
 		color: "Blue",
 		prevo : "Ogremon",
-		evos : ["Titamon", "Devitamamon", "Minervamon", "Fdigitamamon"],
+		evos : ["Fdigitamamon", "Minervamon", "Devitamamon", "Titamon"],
 		eggGroups: ["Amorphous"],
 	},
 	titamon: {
@@ -70506,6 +70699,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	wpachirisu: {
@@ -70553,6 +70747,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 35.5,
 		color: "Purple",
+		prevo : "Mienshao",
 		eggGroups: ["Field", "Humanlike"],
 	},
 	himvirus: {
@@ -70600,6 +70795,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 60.0,
 		color: "Red",
+		prevo : "Kingler",
 		eggGroups: ["Water3"],
 	},
 	dfpsyduck: {
@@ -70671,7 +70867,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 12.9,
 		color: "Purple",
-		evos : ["Acultgoat", "Glaakultist", "Aculzoth", "Aculyellow", "Aculyig", "Aculggua", "Acosoth", "Aculthqua", "Acolthep", "Aculthuga", "Acultchotcho", "Acthulist"],
+		evos : ["Glaakultist", "Aculggua", "Aculyig", "Aculzoth", "Aculyellow", "Acultgoat", "Acthulist", "Aculthuga", "Aculthqua", "Acolthep", "Acultchotcho", "Acosoth"],
 		eggGroups: ["Humanlike"],
 	},
 	acthulist: {
@@ -70849,6 +71045,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 55.0,
 		color: "Red",
+		prevo : "Slugma",
 		eggGroups: ["Amorphous", "Mineral"],
 	},
 	shatterene: {
@@ -70872,6 +71069,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 48.4,
 		color: "White",
+		prevo : "Kirlia",
 		eggGroups: ["Amorphous", "Humanlike"],
 	},
 	steamingo: {
@@ -71224,6 +71422,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 6.0,
 		color: "Yellow",
+		prevo : "Pikachu",
 		eggGroups: ["Field", "Fairy"],
 	},
 	dralts: {
@@ -71248,7 +71447,7 @@ blobbosmechelectric: {
 		weightkg: 20.2,
 		color: "White",
 		prevo : "Dralts",
-		evos : ["Dgardevoir", "Dgallade"],
+		evos : ["Dgallade", "Dgardevoir"],
 		eggGroups: ["Amorphous", "Humanlike"],
 	},
 	dgardevoir: {
@@ -72096,7 +72295,7 @@ blobbosmechelectric: {
 		weightkg: 6.5,
 		color: "Brown",
 		prevo : "Monkid",
-		evos : ["Asrielgot", "Floweyrst"],
+		evos : ["Floweyrst", "Asrielgot"],
 		eggGroups: ["Monster"],
 	},
 	asrielgot: {
@@ -72281,6 +72480,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 6.4,
 		color: "Green",
+		prevo : "Bellsprout",
 		eggGroups: ["Grass"],
 	},
 	tmagnemite: {
@@ -72305,7 +72505,7 @@ blobbosmechelectric: {
 		weightkg: 60.0,
 		color: "Gray",
 		prevo : "Tmagnemite",
-		evos : ["Kaiju Magnezone", "Magnezone"],
+		evos : ["Magnezone", "Kaiju Magnezone"],
 		eggGroups: ["Mineral"],
 	},
 	bjigglypuff: {
@@ -72317,7 +72517,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 5.5,
 		color: "Pink",
-		evos : ["Bwigglytuff", "Spooklypuff"],
+		evos : ["Spooklypuff", "Bwigglytuff"],
 		eggGroups: ["Fairy"],
 	},
 	bwigglytuff: {
@@ -72653,7 +72853,7 @@ blobbosmechelectric: {
 		weightkg: 1116.5,
 		color: "Blue",
 		prevo : "Growlmon",
-		evos : ["Megidramon", "Gallantmon"],
+		evos : ["Gallantmon", "Megidramon"],
 		eggGroups: ["Dragon"],
 	},
 	gallantmon: {
@@ -72789,7 +72989,7 @@ blobbosmechelectric: {
 		weightkg: 16.5,
 		color: "Blue",
 		prevo : "Numemonchuumon",
-		evos : ["Etemon", "Platinumsukamon"],
+		evos : ["Platinumsukamon", "Etemon"],
 		eggGroups: ["Amorphous"],
 	},
 	platinumsukamon: {
@@ -72974,7 +73174,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 16.5,
 		color: "Blue",
-		evos : ["Geremon", "Gekomon"],
+		evos : ["Gekomon", "Geremon"],
 		eggGroups: ["Water1"],
 	},
 	gekomon: {
@@ -73072,6 +73272,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	primplup: {
@@ -73083,6 +73284,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 23.0,
 		color: "Blue",
+		prevo : "Piplup",
 		evos : ["Primpendlup"],
 		eggGroups: ["Water1", "Field"],
 	},
@@ -73164,6 +73366,7 @@ blobbosmechelectric: {
 		heightm: 2.5,
 		weightkg: 220.0,
 		color: "Blue",
+		prevo : "Lapras",
 		eggGroups: ["Monster", "Water1"],
 	},
 	saunarilla: {
@@ -73266,6 +73469,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	ghostmaid: {
@@ -73312,6 +73516,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 340.0,
 		color: "Gray",
+		prevo : "Probopass",
 		eggGroups: ["Mineral"],
 	},
 	adventcirnai: {
@@ -73697,6 +73902,7 @@ blobbosmechelectric: {
 		heightm: 16.4,
 		weightkg: 516.6,
 		color: "White",
+		prevo : "Ralts",
 		eggGroups: ["Amorphous", "Monster"],
 	},
 	kaijucacnea: {
@@ -73708,6 +73914,7 @@ blobbosmechelectric: {
 		heightm: 25.4,
 		weightkg: 2151.3,
 		color: "Green",
+		prevo : "Cacnea",
 		eggGroups: ["Grass", "Humanlike"],
 	},
 	kaijuseedot: {
@@ -73719,6 +73926,7 @@ blobbosmechelectric: {
 		heightm: 25.5,
 		weightkg: 3324.0,
 		color: "Brown",
+		prevo : "Seedot",
 		eggGroups: ["Field", "Grass"],
 	},
 	kaijumachop: {
@@ -73730,6 +73938,7 @@ blobbosmechelectric: {
 		heightm: 15.8,
 		weightkg: 1119.5,
 		color: "Gray",
+		prevo : "Machop",
 		eggGroups: ["Humanlike"],
 	},
 	kaijuvenusaur: {
@@ -73741,6 +73950,7 @@ blobbosmechelectric: {
 		heightm: 22.0,
 		weightkg: 3100.0,
 		color: "Green",
+		prevo : "Ivysaur",
 		eggGroups: ["Monster", "Grass"],
 	},
 	kaijucutiefly: {
@@ -73764,7 +73974,7 @@ blobbosmechelectric: {
 		heightm: 24.2,
 		weightkg: 938.0,
 		color: "Brown",
-		prevo : "Fearolt",
+		prevo : "Fearowfearolt",
 		eggGroups: ["Flying"],
 	},
 	kaijuprimarina: {
@@ -73788,6 +73998,7 @@ blobbosmechelectric: {
 		heightm: 21.4,
 		weightkg: 1140.0,
 		color: "Red",
+		prevo : "Latias",
 		eggGroups: ["Dragon"],
 	},
 	kaijunatu: {
@@ -73799,6 +74010,7 @@ blobbosmechelectric: {
 		heightm: 20.2,
 		weightkg: 922.0,
 		color: "Green",
+		prevo : "Natu",
 		eggGroups: ["Flying", "Monster"],
 	},
 	kaijuflaaffy: {
@@ -73810,6 +74022,7 @@ blobbosmechelectric: {
 		heightm: 26.8,
 		weightkg: 1813.3,
 		color: "Pink",
+		prevo : "Flaaffy",
 		eggGroups: ["Monster", "Field"],
 	},
 	kaijugirafarig: {
@@ -73821,6 +74034,7 @@ blobbosmechelectric: {
 		heightm: 27.5,
 		weightkg: 3241.5,
 		color: "Yellow",
+		prevo : "Girafarig",
 		eggGroups: ["Field", "Monster"],
 	},
 	kaijukrabby: {
@@ -73832,6 +74046,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 6.5,
 		color: "Red",
+		prevo : "Krabby",
 		eggGroups: ["Water3", "Monster"],
 	},
 	kaijuminccino: {
@@ -73843,6 +74058,7 @@ blobbosmechelectric: {
 		heightm: 10.4,
 		weightkg: 715.8,
 		color: "Gray",
+		prevo : "Minccino",
 		evos : ["Kaiju Cinccino"],
 		eggGroups: ["Field", "Monster"],
 	},
@@ -73867,6 +74083,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 4.0,
 		color: "Purple",
+		prevo : "Ditto",
 		eggGroups: ["Ditto"],
 	},
 	kaijustoutland: {
@@ -73878,6 +74095,7 @@ blobbosmechelectric: {
 		heightm: 21.2,
 		weightkg: 1161.0,
 		color: "Gray",
+		prevo : "Herdier",
 		eggGroups: ["Field", "Monster"],
 	},
 	kaijuquilladin: {
@@ -73901,6 +74119,7 @@ blobbosmechelectric: {
 		heightm: 10.7,
 		weightkg: 523.0,
 		color: "Blue",
+		prevo : "Croagunk",
 		eggGroups: ["Humanlike", "Monster"],
 	},
 	kaijuumbreon: {
@@ -73912,6 +74131,7 @@ blobbosmechelectric: {
 		heightm: 25.0,
 		weightkg: 827.0,
 		color: "Black",
+		prevo : "Umbreon",
 		eggGroups: ["Field", "Monster"],
 	},
 	kaijublacephalon: {
@@ -73957,6 +74177,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 81.0,
 		color: "Gray",
+		prevo : "Klang",
 		eggGroups: ["Mineral"],
 	},
 	kaijulileep: {
@@ -73968,6 +74189,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 23.8,
 		color: "Purple",
+		prevo : "Lileep",
 		eggGroups: ["Water3"],
 	},
 	corida: {
@@ -74004,6 +74226,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 11.0,
 		color: "Pink",
+		prevo : "Skitty",
 		eggGroups: ["Field", "Fairy"],
 	},
 	woodman: {
@@ -74123,6 +74346,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	transpareon: {
@@ -74134,6 +74358,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	carmillapire: {
@@ -74414,7 +74639,7 @@ blobbosmechelectric: {
 		weightkg: 12.3,
 		color: "Green",
 		prevo : "Ballbu",
-		evos : ["Snowugg", "Snoware"],
+		evos : ["Snoware", "Snowugg"],
 		eggGroups: ["Field", "Fairy"],
 	},
 	snoware: {
@@ -74450,6 +74675,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 72.0,
 		color: "Green",
+		prevo : "Larvitar",
 		eggGroups: ["Monster", "Humanlike"],
 	},
 	zatu: {
@@ -74461,6 +74687,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 15.0,
 		color: "Green",
+		prevo : "Natu",
 		eggGroups: ["Flying"],
 	},
 	sunsprout: {
@@ -74472,6 +74699,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 1.8,
 		color: "Yellow",
+		prevo : "Sunkern",
 		evos : ["Sunnee"],
 		eggGroups: ["Grass"],
 	},
@@ -74484,6 +74712,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 8.5,
 		color: "Blue",
+		prevo : "Wooper",
 		evos : ["Lanceffish"],
 		eggGroups: ["Water1", "Field"],
 	},
@@ -74555,6 +74784,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 28.5,
 		color: "Blue",
+		prevo : "Marill",
 		eggGroups: ["Water1", "Fairy"],
 	},
 	bchinchou: {
@@ -74566,6 +74796,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 12.0,
 		color: "Blue",
+		prevo : "Chinchou",
 		evos : ["Blanturn"],
 		eggGroups: ["Water2"],
 	},
@@ -74590,6 +74821,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 48.0,
 		color: "Brown",
+		prevo : "Clefairy",
 		eggGroups: ["Humanlike", "Fairy"],
 	},
 	bshuckle: {
@@ -74612,6 +74844,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 125.8,
 		color: "Purple",
+		prevo : "Pineco",
 		eggGroups: ["Bug"],
 	},
 	bcyndaquil: {
@@ -74623,6 +74856,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 7.9,
 		color: "Yellow",
+		prevo : "Cyndaquil",
 		evos : ["Quilava", "Acyndaquil"],
 		eggGroups: ["Field"],
 	},
@@ -74635,7 +74869,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 7.9,
 		color: "Yellow",
-		prevo : "Bcyndaquil",
+		prevo : "Cyndaquilbcyndaquil",
 		evos : ["Quilava"],
 		eggGroups: ["Field"],
 	},
@@ -74850,7 +75084,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 1.9,
 		color: "Black",
-		evos : ["Dootbirb", "Choruseph"],
+		evos : ["Choruseph", "Dootbirb"],
 		eggGroups: ["Flying"],
 	},
 	choruseph: {
@@ -75064,6 +75298,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 40.8,
 		color: "Brown",
+		prevo : "Hoothoot",
 		evos : ["Hoohoo"],
 		eggGroups: ["Flying"],
 	},
@@ -75076,6 +75311,7 @@ blobbosmechelectric: {
 		heightm: 2.1,
 		weightkg: 220.0,
 		color: "Purple",
+		prevo : "Mantyke",
 		eggGroups: ["Water1"],
 	},
 	bcmantine: {
@@ -75087,6 +75323,7 @@ blobbosmechelectric: {
 		heightm: 2.1,
 		weightkg: 220.0,
 		color: "Purple",
+		prevo : "Mantyke",
 		eggGroups: ["Water1"],
 	},
 	bslugma: {
@@ -75098,6 +75335,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 35.0,
 		color: "Red",
+		prevo : "Slugma",
 		evos : ["Magcargo"],
 		eggGroups: ["Amorphous"],
 	},
@@ -75110,6 +75348,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 2.0,
 		color: "Yellow",
+		prevo : "Pichu",
 		evos : ["Pikachu"],
 		eggGroups: ["Undiscovered"],
 	},
@@ -75122,6 +75361,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 46.8,
 		color: "Pink",
+		prevo : "Chansey",
 		eggGroups: ["Fairy"],
 	},
 	blarvitar: {
@@ -75168,6 +75408,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 33.9,
 		color: "Green",
+		prevo : "Poliwhirl",
 		eggGroups: ["Water1"],
 	},
 	bgligar: {
@@ -75179,6 +75420,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 64.8,
 		color: "Purple",
+		prevo : "Gligar",
 		eggGroups: ["Bug"],
 	},
 	caenislancer: {
@@ -75201,6 +75443,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 48.4,
 		color: "White",
+		prevo : "Kirlia",
 		eggGroups: ["Amorphous", "Humanlike"],
 	},
 	kaijuscrafty: {
@@ -75212,6 +75455,7 @@ blobbosmechelectric: {
 		heightm: 11.1,
 		weightkg: 930.0,
 		color: "Red",
+		prevo : "Scraggy",
 		eggGroups: ["Field", "Dragon"],
 	},
 	kaijuporygon: {
@@ -75223,6 +75467,7 @@ blobbosmechelectric: {
 		heightm: 10.8,
 		weightkg: 336.5,
 		color: "Pink",
+		prevo : "Porygon",
 		eggGroups: ["Mineral"],
 	},
 	kaijukabuto: {
@@ -75234,6 +75479,7 @@ blobbosmechelectric: {
 		heightm: 16.5,
 		weightkg: 811.5,
 		color: "Brown",
+		prevo : "Kabuto",
 		eggGroups: ["Water1", "Water3"],
 	},
 	kaijuhappiny: {
@@ -75245,6 +75491,7 @@ blobbosmechelectric: {
 		heightm: 10.6,
 		weightkg: 424.4,
 		color: "Pink",
+		prevo : "Happiny",
 		eggGroups: ["Fairy", "Monster"],
 	},
 	kaijupyukumuku: {
@@ -75268,6 +75515,7 @@ blobbosmechelectric: {
 		heightm: 21.6,
 		weightkg: 375.6,
 		color: "Yellow",
+		prevo : "Hypno",
 		eggGroups: ["Humanlike", "Monster"],
 	},
 	kaijugligar: {
@@ -75279,6 +75527,7 @@ blobbosmechelectric: {
 		heightm: 16.1,
 		weightkg: 464.8,
 		color: "Purple",
+		prevo : "Gligar",
 		eggGroups: ["Bug", "Monster"],
 	},
 	kaijudunsparce: {
@@ -75290,6 +75539,7 @@ blobbosmechelectric: {
 		heightm: 21.5,
 		weightkg: 2114.0,
 		color: "Yellow",
+		prevo : "Dunsparce",
 		eggGroups: ["Field", "Monster"],
 	},
 	kaijuursaring: {
@@ -75301,6 +75551,7 @@ blobbosmechelectric: {
 		heightm: 21.8,
 		weightkg: 1125.8,
 		color: "Brown",
+		prevo : "Teddiursa",
 		eggGroups: ["Field"],
 	},
 	kaijueleko: {
@@ -75371,6 +75622,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 60.0,
 		color: "Red",
+		prevo : "Kingler",
 		eggGroups: ["Water3"],
 	},
 	kaijumachoke: {
@@ -75382,6 +75634,7 @@ blobbosmechelectric: {
 		heightm: 18.5,
 		weightkg: 570.5,
 		color: "Gray",
+		prevo : "Machoke",
 		eggGroups: ["Humanlike"],
 	},
 	kaijushelmet: {
@@ -75393,6 +75646,7 @@ blobbosmechelectric: {
 		heightm: 21.0,
 		weightkg: 1133.0,
 		color: "Gray",
+		prevo : "Shelmet",
 		eggGroups: ["Bug", "Monster"],
 	},
 	kaijuskarmory: {
@@ -75415,6 +75669,7 @@ blobbosmechelectric: {
 		heightm: 15.8,
 		weightkg: 414.3,
 		color: "Yellow",
+		prevo : "Joltik",
 		eggGroups: ["Bug"],
 	},
 	kaijumaractus: {
@@ -75426,6 +75681,7 @@ blobbosmechelectric: {
 		heightm: 21.0,
 		weightkg: 428.0,
 		color: "Green",
+		prevo : "Maractus",
 		eggGroups: ["Grass"],
 	},
 	kaijunosepass: {
@@ -75437,6 +75693,7 @@ blobbosmechelectric: {
 		heightm: 19.0,
 		weightkg: 6697.0,
 		color: "Gray",
+		prevo : "Nosepass",
 		eggGroups: ["Mineral"],
 	},
 	kaijuanorith: {
@@ -75471,7 +75728,7 @@ blobbosmechelectric: {
 		heightm: 21.3,
 		weightkg: 0.1,
 		color: "Purple",
-		prevo : "Hugastly",
+		prevo : "Gastlyhugastly",
 		eggGroups: ["Amorphous", "Monster"],
 	},
 	kaijushroomish: {
@@ -75483,6 +75740,7 @@ blobbosmechelectric: {
 		heightm: 14.4,
 		weightkg: 444.5,
 		color: "Brown",
+		prevo : "Shroomish",
 		eggGroups: ["Monster", "Grass"],
 	},
 	bsentret: {
@@ -75494,6 +75752,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 6.0,
 		color: "Brown",
+		prevo : "Sentret",
 		evos : ["Bfurret"],
 		eggGroups: ["Field"],
 	},
@@ -75518,6 +75777,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 9.5,
 		color: "Blue",
+		prevo : "Totodile",
 		evos : ["Croconaw"],
 		eggGroups: ["Monster", "Water1"],
 	},
@@ -75530,6 +75790,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 125.8,
 		color: "Purple",
+		prevo : "Pineco",
 		eggGroups: ["Bug"],
 	},
 	baipom: {
@@ -75541,6 +75802,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 11.5,
 		color: "Purple",
+		prevo : "Aipom",
 		eggGroups: ["Field"],
 	},
 	qigglybuff: {
@@ -75552,6 +75814,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 1.0,
 		color: "Pink",
+		prevo : "Igglybuff",
 		eggGroups: ["Undiscovered"],
 	},
 	bjumpluff: {
@@ -75563,6 +75826,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 3.0,
 		color: "Blue",
+		prevo : "Skiploom",
 		eggGroups: ["Fairy", "Grass"],
 	},
 	bkingdratwo: {
@@ -75574,6 +75838,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 152.0,
 		color: "Blue",
+		prevo : "Seadra",
 		eggGroups: ["Water1", "Dragon"],
 	},
 	boctillerytwo: {
@@ -75585,6 +75850,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 28.5,
 		color: "Red",
+		prevo : "Octillery",
 		eggGroups: ["Water1", "Water2"],
 	},
 	bteddiursa: {
@@ -75596,6 +75862,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 8.8,
 		color: "Brown",
+		prevo : "Teddiursa",
 		eggGroups: ["Field"],
 	},
 	bsneaseltwo: {
@@ -75607,6 +75874,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 28.0,
 		color: "Black",
+		prevo : "Sneasel",
 		eggGroups: ["Field"],
 	},
 	bsneaselthree: {
@@ -75618,6 +75886,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 28.0,
 		color: "Black",
+		prevo : "Sneasel",
 		eggGroups: ["Field"],
 	},
 	bphanpy: {
@@ -75629,6 +75898,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 33.5,
 		color: "Blue",
+		prevo : "Phanpy",
 		eggGroups: ["Field"],
 	},
 	bsunkern: {
@@ -75640,6 +75910,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 1.8,
 		color: "Yellow",
+		prevo : "Sunkern",
 		evos : ["Sunnee"],
 		eggGroups: ["Grass"],
 	},
@@ -75652,6 +75923,7 @@ blobbosmechelectric: {
 		heightm: 1.8,
 		weightkg: 152.0,
 		color: "Blue",
+		prevo : "Seadra",
 		eggGroups: ["Water1", "Dragon"],
 	},
 	bariados: {
@@ -75663,6 +75935,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 33.5,
 		color: "Red",
+		prevo : "Ariados",
 		eggGroups: ["Bug"],
 	},
 	halfblissey: {
@@ -75829,6 +76102,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 48.4,
 		color: "White",
+		prevo : "Kirlia",
 		eggGroups: ["Amorphous", "Humanlike"],
 	},
 	caesaber: {
@@ -76134,6 +76408,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 6.4,
 		color: "Green",
+		prevo : "Bellsprout",
 		evos : ["Atlasbell"],
 		eggGroups: ["Grass"],
 	},
@@ -76158,6 +76433,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 1.0,
 		color: "Green",
+		prevo : "Hoppip",
 		evos : ["Hoprake"],
 		eggGroups: ["Fairy", "Grass"],
 	},
@@ -76182,6 +76458,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 8.6,
 		color: "Blue",
+		prevo : "Oddish",
 		evos : ["Trickish"],
 		eggGroups: ["Grass"],
 	},
@@ -76206,6 +76483,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 2.0,
 		color: "Green",
+		prevo : "Budew",
 		evos : ["Witherade"],
 		eggGroups: ["Fairy", "Grass"],
 	},
@@ -77025,6 +77303,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 18.2,
 		color: "Yellow",
+		prevo : "Meowth",
 		eggGroups: ["Field"],
 	},
 	aperrserker: {
@@ -77084,6 +77363,7 @@ blobbosmechelectric: {
 		heightm: 3.6,
 		weightkg: 15.0,
 		color: "Pink",
+		prevo : "Corsola",
 		eggGroups: ["Water1", "Water3"],
 	},
 	felekid: {
@@ -77381,6 +77661,7 @@ blobbosmechelectric: {
 		heightm: 1.7,
 		weightkg: 76.5,
 		color: "Yellow",
+		prevo : "Yamask",
 		eggGroups: ["Mineral", "Amorphous"],
 	},
 	dmunna: {
@@ -78900,6 +79181,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 65.5,
 		color: "Pink",
+		prevo : "Lickitung",
 		eggGroups: ["Monster", "Humanlike"],
 	},
 	hukoffing: {
@@ -78948,7 +79230,7 @@ blobbosmechelectric: {
 		weightkg: 120.0,
 		color: "Gray",
 		prevo : "Hurhyhorn",
-		evos : ["Rhyperior", "Gyarth"],
+		evos : ["Gyarth", "Rhyperior"],
 		eggGroups: ["Monster", "Field"],
 	},
 	huchansey: {
@@ -79190,7 +79472,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 6.5,
 		color: "Brown",
-		evos : ["Huvaporeon", "Huflareon", "Hujolteon"],
+		evos : ["Huvaporeon", "Hujolteon", "Huflareon"],
 		eggGroups: ["Field"],
 	},
 	huvaporeon: {
@@ -79639,6 +79921,7 @@ blobbosmechelectric: {
 		heightm: 2.0,
 		weightkg: 130.5,
 		color: "Brown",
+		prevo : "Vigoroth",
 		eggGroups: ["Field"],
 	},
 	snowkitty: {
@@ -79838,6 +80121,7 @@ blobbosmechelectric: {
 		heightm: 2.1,
 		weightkg: 460.0,
 		color: "Black",
+		prevo : "Munchlax",
 		eggGroups: ["Monster"],
 	},
 	mutagon: {
@@ -80015,6 +80299,7 @@ blobbosmechelectric: {
 		heightm: 6.5,
 		weightkg: 253.0,
 		color: "Gray",
+		prevo : "Qwilfish",
 		eggGroups: ["Water2"],
 	},
 	telson: {
@@ -80074,7 +80359,7 @@ blobbosmechelectric: {
 		weightkg: 20.0,
 		color: "Black",
 		prevo : "Polihag",
-		evos : ["Poliwraith", "Snkzombified"],
+		evos : ["Snkzombified", "Poliwraith"],
 		eggGroups: ["Water1"],
 	},
 	poliwraith: {
@@ -80448,6 +80733,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 15.0,
 		color: "Brown",
+		prevo : "Linoone",
 		eggGroups: ["Flying", "Field"],
 	},
 	roclobster: {
@@ -80842,7 +81128,7 @@ blobbosmechelectric: {
 		weightkg: 19.0,
 		color: "Red",
 		prevo : "Rotmander",
-		evos : ["Lichizard", "Snkdragon"],
+		evos : ["Snkdragon", "Lichizard"],
 		eggGroups: ["Monster", "Dragon"],
 	},
 	snkdragon: {
@@ -80976,6 +81262,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 13.6,
 		color: "Red",
+		prevo : "Wurmple",
 		eggGroups: ["Bug"],
 	},
 	sxsalamence: {
@@ -80987,6 +81274,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 102.6,
 		color: "Blue",
+		prevo : "Shelgon",
 		eggGroups: ["Dragon"],
 	},
 	seimenkongou: {
@@ -82049,7 +82337,7 @@ blobbosmechelectric: {
 		heightm: 1.2,
 		weightkg: 36.0,
 		color: "Pink",
-		evos : ["Slowspike", "Slowsidian"],
+		evos : ["Slowsidian", "Slowspike"],
 		eggGroups: ["Monster", "Water1"],
 	},
 	slowsidian: {
@@ -82655,7 +82943,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 6.5,
 		color: "Brown",
-		evos : ["Insecteon", "Caireon", "Barbeon", "Senseion", "Drilleon"],
+		evos : ["Drilleon", "Senseion", "Barbeon", "Insecteon", "Caireon"],
 		eggGroups: ["Field"],
 	},
 	drilleon: {
@@ -83024,7 +83312,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 30.6,
 		color: "Black",
-		evos : ["Grumboar", "Cgrumpig"],
+		evos : ["Cgrumpig", "Grumboar"],
 		eggGroups: ["Field"],
 	},
 	cgrumpig: {
@@ -83380,6 +83668,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	eobstagoon: {
@@ -83667,7 +83956,7 @@ blobbosmechelectric: {
 		heightm: 0.6,
 		weightkg: 7.5,
 		color: "Pink",
-		evos : ["Scpee3166", "Gorefielf"],
+		evos : ["Gorefielf", "Scpee3166"],
 		eggGroups: ["Field"],
 	},
 	gorefielf: {
@@ -83923,6 +84212,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 25.5,
 		color: "Green",
+		prevo : "Eevee",
 		eggGroups: ["Field"],
 	},
 	scpee504: {
@@ -83968,6 +84258,7 @@ blobbosmechelectric: {
 		heightm: 1.1,
 		weightkg: 97.0,
 		color: "Green",
+		prevo : "Turtwig",
 		evos : ["Btorterra"],
 		eggGroups: ["Monster", "Grass"],
 	},
@@ -83992,6 +84283,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 23.0,
 		color: "Blue",
+		prevo : "Piplup",
 		evos : ["Bempoleon"],
 		eggGroups: ["Water1", "Field"],
 	},
@@ -84016,6 +84308,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 9.5,
 		color: "Blue",
+		prevo : "Shinx",
 		evos : ["Bachichi"],
 		eggGroups: ["Field"],
 	},
@@ -84053,6 +84346,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 31.5,
 		color: "Blue",
+		prevo : "Cranidos",
 		evos : ["Brampardos"],
 		eggGroups: ["Monster"],
 	},
@@ -84077,6 +84371,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 5.5,
 		color: "Yellow",
+		prevo : "Combee",
 		evos : ["Bvespiquen"],
 		eggGroups: ["Bug"],
 	},
@@ -84101,6 +84396,7 @@ blobbosmechelectric: {
 		heightm: 1.3,
 		weightkg: 187.0,
 		color: "Green",
+		prevo : "Bronzor",
 		eggGroups: ["Mineral"],
 	},
 	bgible: {
@@ -84112,6 +84408,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 20.5,
 		color: "Blue",
+		prevo : "Gible",
 		evos : ["Bgabite"],
 		eggGroups: ["Monster", "Dragon"],
 	},
@@ -84149,6 +84446,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 49.5,
 		color: "Brown",
+		prevo : "Hippopotas",
 		evos : ["Bhippowdon"],
 		eggGroups: ["Field"],
 	},
@@ -84173,6 +84471,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 27.0,
 		color: "Green",
+		prevo : "Carnivine",
 		eggGroups: ["Grass"],
 	},
 	bfinneon: {
@@ -84184,6 +84483,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 7.0,
 		color: "Blue",
+		prevo : "Finneon",
 		evos : ["Blumineon"],
 		eggGroups: ["Water2"],
 	},
@@ -84208,6 +84508,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 50.5,
 		color: "White",
+		prevo : "Snover",
 		evos : ["Babomasnow"],
 		eggGroups: ["Monster", "Grass"],
 	},
@@ -84232,6 +84533,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 38.0,
 		color: "White",
+		prevo : "Togetic",
 		eggGroups: ["Flying", "Fairy"],
 	},
 	byanmega: {
@@ -84243,6 +84545,7 @@ blobbosmechelectric: {
 		heightm: 1.9,
 		weightkg: 51.5,
 		color: "Green",
+		prevo : "Yanma",
 		eggGroups: ["Bug"],
 	},
 	bprobopass: {
@@ -84254,6 +84557,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 340.0,
 		color: "Gray",
+		prevo : "Nosepass",
 		eggGroups: ["Mineral"],
 	},
 	bregigigas: {
@@ -84870,7 +85174,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 3.2,
 		color: "White",
-		evos : ["Punchortz", "Lingereist"],
+		evos : ["Lingereist", "Punchortz"],
 		eggGroups: ["Mineral", "Amorphous"],
 	},
 	punchortz: {
@@ -85004,7 +85308,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 34.5,
 		color: "Gray",
-		evos : ["Nyuvel2", "Nyuvel0"],
+		evos : ["Nyuvel0", "Nyuvel2"],
 		eggGroups: ["Mineral"],
 	},
 	nyuvel2: {
@@ -85350,7 +85654,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 6.3,
 		color: "Brown",
-		evos : ["Breadiot", "Cookiot", "Pastiot"],
+		evos : ["Pastiot", "Cookiot", "Breadiot"],
 		eggGroups: ["Amorphous"],
 	},
 	breadiot: {
@@ -85579,7 +85883,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 5.5,
 		color: "Green",
-		evos : ["Corottle", "Buktopple"],
+		evos : ["Buktopple", "Corottle"],
 		eggGroups: ["Grass", "Flying"],
 	},
 	buktopple: {
@@ -86240,7 +86544,7 @@ blobbosmechelectric: {
 		weightkg: 14.5,
 		color: "Blue",
 		prevo : "Augumon",
-		evos : ["Metalgreymonv", "Skullgreymon", "Mastertyrannomon"],
+		evos : ["Mastertyrannomon", "Skullgreymon", "Metalgreymonv"],
 		eggGroups: ["Mineral", "Dragon"],
 	},
 	mastertyrannomon: {
@@ -86359,6 +86663,7 @@ blobbosmechelectric: {
 		heightm: 2.2,
 		weightkg: 90.5,
 		color: "Purple",
+		prevo : "Staryu",
 		eggGroups: ["Water3"],
 	},
 	intestinela: {
@@ -86806,6 +87111,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 36.5,
 		color: "Pink",
+		prevo : "Porygon",
 		eggGroups: ["Mineral"],
 	},
 	swordygon: {
@@ -86817,6 +87123,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 36.5,
 		color: "Pink",
+		prevo : "Porygon",
 		eggGroups: ["Mineral"],
 	},
 	shieldygon: {
@@ -86828,6 +87135,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 36.5,
 		color: "Pink",
+		prevo : "Porygon",
 		eggGroups: ["Mineral"],
 	},
 	cosplaypikachu: {
@@ -86861,6 +87169,7 @@ blobbosmechelectric: {
 		heightm: 0.5,
 		weightkg: 5.0,
 		color: "Green",
+		prevo : "Treecko",
 		eggGroups: ["Monster", "Dragon"],
 	},
 	btorchic: {
@@ -86872,6 +87181,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 2.5,
 		color: "Red",
+		prevo : "Torchic",
 		evos : ["Latiaziken"],
 		eggGroups: ["Field"],
 	},
@@ -86896,6 +87206,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 29.9,
 		color: "Purple",
+		prevo : "Shellos",
 		eggGroups: ["Water1", "Amorphous"],
 	},
 	hidelra: {
@@ -86988,6 +87299,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 51.0,
 		color: "Black",
+		prevo : "Sneasel",
 		eggGroups: ["Field"],
 	},
 	dmagikarp: {
@@ -87035,6 +87347,7 @@ blobbosmechelectric: {
 		heightm: 0.9,
 		weightkg: 16.0,
 		color: "Red",
+		prevo : "Delibird",
 		evos : ["Krampusird"],
 		eggGroups: ["Amorphous", "Field"],
 	},
@@ -87047,6 +87360,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 40.6,
 		color: "Red",
+		prevo : "Smoochum",
 		eggGroups: ["Humanlike"],
 	},
 	hyonix: {
@@ -87058,7 +87372,7 @@ blobbosmechelectric: {
 		heightm: 8.8,
 		weightkg: 210.0,
 		color: "Gray",
-		evos : ["Malicix", "Steelix"],
+		evos : ["Steelix", "Malicix"],
 		eggGroups: ["Mineral"],
 	},
 	malicix: {
@@ -87175,6 +87489,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 71.2,
 		color: "Brown",
+		prevo : "Stantler",
 		eggGroups: ["Field"],
 	},
 	armewtwo: {
@@ -87197,6 +87512,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 19.8,
 		color: "Blue",
+		prevo : "Taillow",
 		eggGroups: ["Flying"],
 	},
 	kangaskhid: {
@@ -87230,6 +87546,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 48.4,
 		color: "White",
+		prevo : "Kirlia",
 		eggGroups: ["Amorphous", "Humanlike"],
 	},
 	seqola: {
@@ -87382,6 +87699,7 @@ blobbosmechelectric: {
 		heightm: 1.0,
 		weightkg: 28.0,
 		color: "Green",
+		prevo : "Maractus",
 		eggGroups: ["Grass"],
 	},
 	princesspeach: {
@@ -88339,6 +88657,7 @@ blobbosmechelectric: {
 		heightm: 2.2,
 		weightkg: 92.5,
 		color: "Red",
+		prevo : "Charmeleon",
 		eggGroups: ["Monster", "Dragon"],
 	},
 	lozmidna: {
@@ -88813,6 +89132,7 @@ blobbosmechelectric: {
 		heightm: 2.2,
 		weightkg: 310.0,
 		color: "Green",
+		prevo : "Grotle",
 		eggGroups: ["Monster", "Grass"],
 	},
 	tailsprower: {
@@ -89071,6 +89391,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 18.5,
 		color: "Brown",
+		prevo : "Raticate",
 		eggGroups: ["Field"],
 	},
 	mumenrider: {
@@ -89192,7 +89513,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 5.5,
 		color: "Pink",
-		evos : ["Shy Fly Guy", "Shy Gal", "Shyguyghost"],
+		evos : ["Shyguyghost", "Shy Gal", "Shy Fly Guy"],
 		eggGroups: ["Monster"],
 	},
 	shyflyguy: {
@@ -89240,7 +89561,7 @@ blobbosmechelectric: {
 		heightm: 0.3,
 		weightkg: 5.5,
 		color: "Pink",
-		evos : ["Dry Bones", "Koopa Paratroopa"],
+		evos : ["Koopa Paratroopa", "Dry Bones"],
 		eggGroups: ["Monster"],
 	},
 	koopaparatroopa: {
@@ -89332,6 +89653,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 40.5,
 		color: "Purple",
+		prevo : "Haunter",
 		eggGroups: ["Amorphous"],
 	},
 	fedorakirlia: {
@@ -89343,6 +89665,7 @@ blobbosmechelectric: {
 		heightm: 0.8,
 		weightkg: 20.2,
 		color: "White",
+		prevo : "Ralts",
 		evos : ["Gardevoir"],
 		eggGroups: ["Amorphous", "Humanlike"],
 	},
@@ -90103,6 +90426,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 79.5,
 		color: "Black",
+		prevo : "Blitzle",
 		eggGroups: ["Field"],
 	},
 	maytias: {
@@ -90114,6 +90438,7 @@ blobbosmechelectric: {
 		heightm: 1.4,
 		weightkg: 40.0,
 		color: "Red",
+		prevo : "Latias",
 		eggGroups: ["Dragon"],
 	},
 	hildaroark: {
@@ -90125,6 +90450,7 @@ blobbosmechelectric: {
 		heightm: 1.6,
 		weightkg: 81.1,
 		color: "Gray",
+		prevo : "Zorua",
 		eggGroups: ["Field"],
 	},
 	beachpatchi: {
@@ -91001,7 +91327,7 @@ blobbosmechelectric: {
 		heightm: 0.4,
 		weightkg: 4.1,
 		color: "Brown",
-		evos : ["Wackvirgin", "Wackmuscleman", "Sprite007", "Wackchad"],
+		evos : ["Wackmuscleman", "Wackvirgin", "Sprite007", "Wackchad"],
 		eggGroups: ["Field"],
 	},
 	wackmuscleman: {
@@ -91570,6 +91896,7 @@ blobbosmechelectric: {
 		heightm: 0.7,
 		weightkg: 19.0,
 		color: "Brown",
+		prevo : "Growlithe",
 		evos : ["Harcanine"],
 		eggGroups: ["Field"],
 	},
@@ -91594,6 +91921,7 @@ blobbosmechelectric: {
 		heightm: 1.5,
 		weightkg: 41.0,
 		color: "Red",
+		prevo : "Rufflet",
 		eggGroups: ["Flying"],
 	},
 	btakua: {


### PR DESCRIPTION
## Description
-Added Gen 6-8 vanilla pokemons modifications from Wack
-Added missing vanilla pre-evos for Wack pokemons
-Updated tiers of mons with new pre-evos (LC -> NFE)

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities