### PR TITLE
PP functionality change and wack updates

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -713,7 +713,6 @@ export const Formats: FormatList = [
 			'Terastal Clause',
 			'Standard',
 			'Dynamax Clause',
-			'Sketch Post-Gen 7 Moves',
 			'Overflow Stat Mod',
 		],
 		banlist: [
@@ -732,7 +731,6 @@ export const Formats: FormatList = [
 			'Terastal Clause',
 			'Standard',
 			'Dynamax Clause',
-			'Sketch Post-Gen 7 Moves',
 			'Overflow Stat Mod',
 		],
 		banlist: [
@@ -752,7 +750,6 @@ export const Formats: FormatList = [
 			'Not Fully Evolved',
 			'Standard',
 			'Dynamax Clause',
-			'Sketch Post-Gen 7 Moves',
 			'Overflow Stat Mod',
 		],
 		banlist: [
@@ -772,7 +769,6 @@ export const Formats: FormatList = [
 			'Little Cup',
 			'Standard',
 			'Dynamax Clause',
-			'Sketch Post-Gen 7 Moves',
 			'Overflow Stat Mod',
 		],
 		banlist: [
@@ -792,7 +788,6 @@ export const Formats: FormatList = [
 			'Same Type Clause',
 			'Standard',
 			'Dynamax Clause',
-			'Sketch Post-Gen 7 Moves',
 			'Overflow Stat Mod',
 		],
 		banlist: [
@@ -828,7 +823,6 @@ export const Formats: FormatList = [
 			'Standard',
 			'Dynamax Clause',
 			'Swagger Clause',
-			'Sketch Post-Gen 7 Moves',
 			'Overflow Stat Mod',
 		],
 		banlist: ['DUber', 'Uber', 'Arena Trap', 'Moody', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
@@ -850,7 +844,6 @@ export const Formats: FormatList = [
 			'Standard',
 			'Dynamax Clause',
 			'Swagger Clause',
-			'Sketch Post-Gen 7 Moves',
 			'Overflow Stat Mod',
 		],
 		banlist: ['DUber', 'Uber', 'Arena Trap', 'Moody', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -10253,8 +10253,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				pokemon.baseMoveSlots[heroicStrike] = {
 					move: move.name,
 					id: move.id,
-					pp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
-					maxpp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
+					pp: (move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5),
+					maxpp: (move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5),
 					target: move.target,
 					disabled: false,
 					disabledSource: '',
@@ -11460,8 +11460,8 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				pokemon.baseMoveSlots[lightOfRuin] = {
 					move: move.name,
 					id: move.id,
-					pp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
-					maxpp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
+					pp: (move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5),
+					maxpp: (move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5),
 					target: move.target,
 					disabled: false,
 					disabledSource: '',

--- a/data/items.ts
+++ b/data/items.ts
@@ -17688,9 +17688,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	weakeningwhip: {
 		name: "Weakening Whip",
 		spritenum: 0,
+		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({atk: -1}, source, target, this.effect)
+			if (move.totalDamage) {
+				if (this.randomChance(4,10)) {
+					this.boost({atk: -1}, source, target, this.effect)
+				}
 			}
 		},
 		num: 67397,
@@ -17700,9 +17703,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	shatteringhammer: {
 		name: "Shattering Hammer",
 		spritenum: 0,
+		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({def: -1}, source, target, this.effect)
+			if (move.totalDamage) {
+				if (this.randomChance(4,10)) {
+					this.boost({def: -1}, source, target, this.effect)
+				}
 			}
 		},
 		num: 67398,
@@ -17712,9 +17718,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	distracttrumpet: {
 		name: "Distract Trumpet",
 		spritenum: 0,
+		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({spa: -1},source, target, this.effect)
+			if (move.totalDamage) {
+				if (this.randomChance(4,10)) {
+					this.boost({spa: -1}, source, target, this.effect)
+				}
 			}
 		},
 		num: 67399,
@@ -17724,9 +17733,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	enfeeblescepter: {
 		name: "Enfeeble Scepter",
 		spritenum: 0,
+		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({spd: -1}, source, target, this.effect)
+			if (move.totalDamage) {
+				if (this.randomChance(4,10)) {
+					this.boost({spd: -1}, source, target, this.effect)
+				}
 			}
 		},
 		num: 67400,
@@ -17736,9 +17748,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	gooeygloves: {
 		name: "Gooey Gloves",
 		spritenum: 0,
+		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({spe: -1}, source, target, this.effect)
+			if (move.totalDamage) {
+				if (this.randomChance(4,10)) {
+					this.boost({spe: -1}, source, target, this.effect)
+				}
 			}
 		},
 		num: 67401,
@@ -17748,9 +17763,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	blindingprism: {
 		name: "Blinding Prism",
 		spritenum: 0,
+		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({accuracy: -1}, source, target, this.effect)
+			if (move.totalDamage) {
+				if (this.randomChance(4,10)) {
+					this.boost({accuracy: -1}, source, target, this.effect)
+				}
 			}
 		},
 		num: 67402,
@@ -17760,9 +17778,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	alluringnectar: {
 		name: "Alluring Nectar",
 		spritenum: 0,
+		onAfterMoveSecondarySelfPriority: -1,
 		onAfterMoveSecondarySelf(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({evasion: -1}, source, target, this.effect)
+			if (move.totalDamage) {
+				if (this.randomChance(4,10)) {
+					this.boost({evasion: -1}, source, target, this.effect)
+				}
 			}
 		},
 		num: 67403,

--- a/data/items.ts
+++ b/data/items.ts
@@ -17688,9 +17688,9 @@ export const Items: {[itemid: string]: ItemData} = {
 	weakeningwhip: {
 		name: "Weakening Whip",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(target, source, move) {
 			if (this.randomChance(4,10)) {
-				this.boost({atk: -1}, target, source, this.effect)
+				this.boost({atk: -1}, source, target, this.effect)
 			}
 		},
 		num: 67397,
@@ -17700,9 +17700,9 @@ export const Items: {[itemid: string]: ItemData} = {
 	shatteringhammer: {
 		name: "Shattering Hammer",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(target, source, move) {
 			if (this.randomChance(4,10)) {
-				this.boost({atk: -1}, target, source, this.effect)
+				this.boost({def: -1}, source, target, this.effect)
 			}
 		},
 		num: 67398,
@@ -17712,9 +17712,9 @@ export const Items: {[itemid: string]: ItemData} = {
 	distracttrumpet: {
 		name: "Distract Trumpet",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(target, source, move) {
 			if (this.randomChance(4,10)) {
-				this.boost({def: -1}, target, source, this.effect)
+				this.boost({spa: -1},source, target, this.effect)
 			}
 		},
 		num: 67399,
@@ -17724,9 +17724,9 @@ export const Items: {[itemid: string]: ItemData} = {
 	enfeeblescepter: {
 		name: "Enfeeble Scepter",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(target, source, move) {
 			if (this.randomChance(4,10)) {
-				this.boost({spa: -1}, target, source, this.effect)
+				this.boost({spd: -1}, source, target, this.effect)
 			}
 		},
 		num: 67400,
@@ -17736,9 +17736,9 @@ export const Items: {[itemid: string]: ItemData} = {
 	gooeygloves: {
 		name: "Gooey Gloves",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(target, source, move) {
 			if (this.randomChance(4,10)) {
-				this.boost({spd: -1}, target, source, this.effect)
+				this.boost({spe: -1}, source, target, this.effect)
 			}
 		},
 		num: 67401,
@@ -17748,9 +17748,9 @@ export const Items: {[itemid: string]: ItemData} = {
 	blindingprism: {
 		name: "Blinding Prism",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(target, source, move) {
 			if (this.randomChance(4,10)) {
-				this.boost({spe: -1}, target, source, this.effect)
+				this.boost({accuracy: -1}, source, target, this.effect)
 			}
 		},
 		num: 67402,
@@ -17760,9 +17760,9 @@ export const Items: {[itemid: string]: ItemData} = {
 	alluringnectar: {
 		name: "Alluring Nectar",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
+		onAfterMoveSecondarySelf(target, source, move) {
 			if (this.randomChance(4,10)) {
-				this.boost({accuracy: -1}, target, source, this.effect)
+				this.boost({evasion: -1}, source, target, this.effect)
 			}
 		},
 		num: 67403,
@@ -17772,9 +17772,12 @@ export const Items: {[itemid: string]: ItemData} = {
 	curseddoll: {
 		name: "Cursed Doll",
 		spritenum: 0,
-		onAfterMoveSecondary(target, source, move) {
-			if (this.randomChance(4,10)) {
-				this.boost({evasion: -1}, target, source, this.effect)
+		onDamagingHit(damage, target, source, move) {
+			if (source.volatiles['disable']) return;
+			if (!move.isMax && !move.isFutureMove && move.id !== 'struggle') {
+				if (this.randomChance(3, 10)) {
+					source.addVolatile('disable', this.effectState.target);
+				}
 			}
 		},
 		num: 67404,

--- a/data/mods/gen1/moves.ts
+++ b/data/mods/gen1/moves.ts
@@ -503,7 +503,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				move: move.name,
 				id: move.id,
 				pp: source.moveSlots[moveslot].pp,
-				maxpp: move.pp * 8 / 5,
+				maxpp: Math.floor(move.pp * 8 / 5),
 				target: move.target,
 				disabled: false,
 				used: false,

--- a/data/mods/gen4/moves.ts
+++ b/data/mods/gen4/moves.ts
@@ -1032,7 +1032,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 				move: move.name,
 				id: move.id,
 				pp: 5,
-				maxpp: move.pp * 8 / 5,
+				maxpp: Math.floor(move.pp * 8 / 5),
 				disabled: false,
 				used: false,
 				virtual: true,

--- a/data/mods/ssb/abilities.ts
+++ b/data/mods/ssb/abilities.ts
@@ -84,7 +84,7 @@ export function changeMoves(context: Battle, pokemon: Pokemon, newMoves: (string
 			id: move.id,
 			// eslint-disable-next-line max-len
 			pp: ((move.noPPBoosts || move.isZ) ? Math.floor(move.pp * carryOver[slot]) : Math.floor((move.pp * (8 / 5)) * carryOver[slot])),
-			maxpp: ((move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5),
+			maxpp: ((move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5)),
 			target: move.target,
 			disabled: false,
 			disabledSource: '',
@@ -714,8 +714,8 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			const sketchedMove = {
 				move: move.name,
 				id: move.id,
-				pp: (move.pp * 8 / 5),
-				maxpp: (move.pp * 8 / 5),
+				pp: (Math.floor(move.pp * 8 / 5)),
+				maxpp: (Math.floor(move.pp * 8 / 5)),
 				target: move.target,
 				disabled: false,
 				used: false,

--- a/data/mods/ssb/moves.ts
+++ b/data/mods/ssb/moves.ts
@@ -1025,7 +1025,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						move: moveData.name,
 						id: moveData.id,
 						pp: Math.floor(moveData.pp * (moveSlot.pp / moveSlot.maxpp)),
-						maxpp: ((moveData.noPPBoosts || moveData.isZ) ? moveData.pp : moveData.pp * 8 / 5),
+						maxpp: ((moveData.noPPBoosts || moveData.isZ) ? moveData.pp : Math.floor(moveData.pp * 8 / 5)),
 						target: moveData.target,
 						disabled: false,
 						disabledSource: '',
@@ -2613,8 +2613,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						const newSlot = {
 							id: newMove.id,
 							move: newMove.name,
-							pp: newMove.pp * 8 / 5,
-							maxpp: newMove.pp * 8 / 5,
+							pp: Math.floor(newMove.pp * 8 / 5),
+							maxpp: Math.floor(newMove.pp * 8 / 5),
 							disabled: slot.disabled,
 							used: false,
 						};
@@ -2639,8 +2639,8 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 						const newSlot = {
 							id: newMove.id,
 							move: newMove.name,
-							pp: newMove.pp * 8 / 5,
-							maxpp: newMove.pp * 8 / 5,
+							pp: Math.floor(newMove.pp * 8 / 5),
+							maxpp: Math.floor(newMove.pp * 8 / 5),
 							disabled: slot.disabled,
 							used: false,
 						};

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -2218,8 +2218,8 @@ export const Rulesets: {[k: string]: FormatData} = {
 						...pokemon.baseMoveSlots, {
 							id: move.id,
 							move: move.name,
-							pp: move.pp * 8 / 5,
-							maxpp: move.pp * 8 / 5,
+							pp: Math.floor(move.pp * 8 / 5),
+							maxpp: Math.floor(move.pp * 8 / 5),
 							target: move.target,
 							disabled: false,
 							disabledSource: '',

--- a/data/text/items.ts
+++ b/data/text/items.ts
@@ -4812,7 +4812,7 @@ export const ItemsText: {[k: string]: ItemText} = {
 	},
 	cowbell: {
 		name: "Cowbell",
-		desc: "Slightly increases Miltank's defenses and heals it every turn.",
+		desc: "Slightly increases Miltank's defenses, heals it every turn and Atk and Def Berserk.",
 	},
 	iaraytberry: {
 		name: "Iarayt Berry",

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -2462,7 +2462,7 @@ export const Chat = new class {
 		}
 		buf += `<span class="col widelabelcol"><em>Accuracy</em><br>${typeof move.accuracy === 'number' ? (move.accuracy + '%') : '—'}</span> `;
 		const basePP = move.pp || 1;
-		const pp = Math.floor(move.noPPBoosts ? basePP : basePP * 8 / 5);
+		const pp = Math.floor(move.noPPBoosts ? basePP : Math.floor(basePP * 8 / 5));
 		buf += `<span class="col pplabelcol"><em>PP</em><br>${pp}</span> `;
 		buf += `<span class="col movedesccol">${move.shortDesc || move.desc}</span> `;
 		buf += `</li><li style="clear:both"></li></ul>`;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -2495,8 +2495,8 @@ export class Battle {
 					pokemon.baseMoveSlots[ironHead] = {
 						move: move.name,
 						id: move.id,
-						pp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
-						maxpp: (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5,
+						pp: (move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5),
+						maxpp: (move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5),
 						target: move.target,
 						disabled: false,
 						disabledSource: '',

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -323,7 +323,7 @@ export class Pokemon {
 				if (!set.hpType) set.hpType = move.type;
 				move = this.battle.dex.moves.get('hiddenpower');
 			}
-			let basepp = (move.noPPBoosts || move.isZ) ? move.pp : move.pp * 8 / 5;
+			let basepp = (move.noPPBoosts || move.isZ) ? move.pp : Math.floor(move.pp * 8 / 5);
 			if (this.battle.gen < 3) basepp = Math.min(61, basepp);
 			this.baseMoveSlots.push({
 				move: move.name,


### PR DESCRIPTION
## Description
-Moves can now have any PP values without its MaxPP variant turning into a float. This has no impact on existing vanilla/clover moves since the formula "numberdivisibleby5 x 8 / 5" always result into an integer and not a float. It was made so that I could give the proper number of PPs to Wack moves in the future
-Fixed lowering stat items and Cursed Doll
-Banned Sketched Move
-Updated Cowbell item description

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities