### PR TITLE
Small Wack fixes

### DIFF
--- a/data/mods/wack/pokedex.ts
+++ b/data/mods/wack/pokedex.ts
@@ -2421,7 +2421,7 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	toxapex: {
 		inherit: true,
 		types: ["Water", "Poison"],
-		abilities: {0: "Limber", 1: "Merciless"},
+		abilities: {0: "Limber", 1: "Merciless", H: "Regenerator"},
 	},
 	mudsdale: {
 		inherit: true,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -39296,10 +39296,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		boosts: {
-			accuracy: 2,
+		secondary: {
+			chance: 100,
+			self: {
+				boosts: {
+					accuracy: 2,
+				}
+			}
 		},
-		secondary: null,
 		target: "normal",
 		type: "Light",
 		isNonstandard: "Future",
@@ -39456,6 +39460,19 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 1,
 		volatileStatus: 'substitute',
+		onTryHit(source) {
+			if (source.volatiles['substitute']) {
+				this.add('-fail', source, 'move: Substitute');
+				return this.NOT_FAIL;
+			}
+			if (source.hp <= source.maxhp / 4 || source.maxhp === 1) { // Shedinja clause
+				this.add('-fail', source, 'move: Substitute', '[weak]');
+				return this.NOT_FAIL;
+			}
+		},
+		onHit(target) {
+			this.directDamage(target.maxhp / 4);
+		},
 		flags: {snatch: 1},
 		secondary: null,
 		target: "self",


### PR DESCRIPTION
## Description
-Fixed "Beacon" boost not being a secondary and affecting the target's accuracy instead of the user
-Fixed "Wild Mushrooms" not removing HP on successful substitute
-Added back missing "Regenerator" to Toxapex abilities

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities