### PR TITLE
Wack "Double Slap" hotfix

### DIFF
--- a/data/mods/wack/moves.ts
+++ b/data/mods/wack/moves.ts
@@ -1022,7 +1022,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	doubleslap: {
 		inherit: true,
-		basePower: 90,
+		accuracy: 90,
 		isNonstandard: null,
 	},
 	dragondarts: {


### PR DESCRIPTION
## Description
Updated Wack's "Double Slap" to the correct attribute change (bp -> acc)

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities