### PR TITLE
Fixed Wack Parental Bond/Instruct not double hitting on spread moves

### DIFF
--- a/data/mods/wack/abilities.ts
+++ b/data/mods/wack/abilities.ts
@@ -547,7 +547,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				move.multihitType = 'parentalbond';
 			}
 		},
-		desc: "This Pokemon's damaging moves become multi-hit moves that hit twice. Does not affect multi-hit moves or moves that have multiple targets.",
+		desc: "This Pokemon's damaging moves become multi-hit moves that hit twice. Does not affect multi-hit moves.",
 		shortDesc: "This Pokemon's damaging moves hit twice.",
 	},
 	// Gen5 vanilla abilities

--- a/data/mods/wack/abilities.ts
+++ b/data/mods/wack/abilities.ts
@@ -538,7 +538,15 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	},
 	parentalbond: {
 		inherit: true,
-		//Changes made in sim/battle-actions.ts
+		//Damage changes made in sim/battle-actions.ts
+		onPrepareHit(source, target, move) {
+			if (move.category === 'Status' || move.selfdestruct || move.multihit) return;
+			if (['dynamaxcannon', 'endeavor', 'fling', 'iceball', 'rollout'].includes(move.id)) return;
+			if (!move.flags['charge'] && !move.isZ && !move.isMax) {
+				move.multihit = 2;
+				move.multihitType = 'parentalbond';
+			}
+		},
 		desc: "This Pokemon's damaging moves become multi-hit moves that hit twice. Does not affect multi-hit moves or moves that have multiple targets.",
 		shortDesc: "This Pokemon's damaging moves hit twice.",
 	},

--- a/data/mods/wack/moves.ts
+++ b/data/mods/wack/moves.ts
@@ -1496,7 +1496,7 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			onPrepareHit(source, target, move) {
 				if (move.category === 'Status' || move.selfdestruct || move.multihit) return;
 				if (['dynamaxcannon', 'endeavor', 'fling', 'iceball', 'rollout'].includes(move.id)) return;
-				if (!move.flags['charge'] && !move.spreadHit && !move.isZ && !move.isMax) {
+				if (!move.flags['charge'] && !move.isZ && !move.isMax) {
 					if (source.getVolatile('instruct')) {
 						this.add('-activate', source, "  [TARGET] followed [POKEMON]'s instructions!")
 						this.add('-end', source, 'Instruct');


### PR DESCRIPTION
## Description
Moves with multiple targets (Surf, EQ...) didn't hit twice like in Wack.

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities