### PR TITLE
Hotfix Wack bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -717,12 +717,12 @@ export const Formats: FormatList = [
 		],
 		banlist: [
 			'Uber', 'Arena Trap', 'Moody', 'Sand Veil', 'Snow Cloak', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
-			'Angel Powder + Substitute', 'Angel Powder + Protect', 'Angel Powder + Detect', 'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
+			'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
 			'Cryaa', 'aaryC', 'Drizzle', 'Drought', 'Snow Warning', 'Sand Stream', 'Shadow Call', 'Acid Cloudburst', 'Thunderstorm',
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Xerneas', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -736,12 +736,12 @@ export const Formats: FormatList = [
 		],
 		banlist: [
 			'Arena Trap', 'Moody', 'Sand Veil', 'Snow Cloak', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
-			'Angel Powder + Substitute', 'Angel Powder + Protect', 'Angel Powder + Detect', 'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
+			'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
 			'Cryaa', 'aaryC', 'Drizzle', 'Drought', 'Snow Warning', 'Sand Stream', 'Shadow Call', 'Acid Cloudburst', 'Thunderstorm',
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Xerneas', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -756,12 +756,12 @@ export const Formats: FormatList = [
 		],
 		banlist: [
 			'Arena Trap', 'Moody', 'Sand Veil', 'Snow Cloak', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
-			'Angel Powder + Substitute', 'Angel Powder + Protect', 'Angel Powder + Detect', 'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
+			'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
 			'Cryaa', 'aaryC', 'Drizzle', 'Drought', 'Snow Warning', 'Sand Stream', 'Shadow Call', 'Acid Cloudburst', 'Thunderstorm',
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Xerneas', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -776,12 +776,12 @@ export const Formats: FormatList = [
 		],
 		banlist: [
 			'Arena Trap', 'Moody', 'Sand Veil', 'Snow Cloak', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
-			'Angel Powder + Substitute', 'Angel Powder + Protect', 'Angel Powder + Detect', 'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
+			'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
 			'Cryaa', 'aaryC', 'Drizzle', 'Drought', 'Snow Warning', 'Sand Stream', 'Shadow Call', 'Acid Cloudburst', 'Thunderstorm',
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Xerneas', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -796,12 +796,12 @@ export const Formats: FormatList = [
 		],
 		banlist: [
 			'Uber', 'Arena Trap', 'Moody', 'Sand Veil', 'Snow Cloak', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
-			'Angel Powder + Substitute', 'Angel Powder + Protect', 'Angel Powder + Detect', 'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
+			'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
 			'Cryaa', 'aaryC', 'Drizzle', 'Drought', 'Snow Warning', 'Sand Stream', 'Shadow Call', 'Acid Cloudburst', 'Thunderstorm',
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Xerneas', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -831,12 +831,12 @@ export const Formats: FormatList = [
 			'Overflow Stat Mod',
 		],
 		banlist: ['DUber', 'Uber', 'Arena Trap', 'Moody', 'Sand Veil', 'Snow Cloak', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
-		'Angel Powder + Substitute', 'Angel Powder + Protect', 'Angel Powder + Detect', 'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
+		'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
 		'Cryaa', 'aaryC', 'Drizzle', 'Drought', 'Snow Warning', 'Sand Stream', 'Shadow Call', 'Acid Cloudburst', 'Thunderstorm',
 		'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 		'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 		'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-		'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Xerneas', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+		'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -853,12 +853,12 @@ export const Formats: FormatList = [
 			'Overflow Stat Mod',
 		],
 		banlist: ['DUber', 'Uber', 'Arena Trap', 'Moody', 'Sand Veil', 'Snow Cloak', 'Computer Bug', 'Baton Pass', 'Gods Endurance', 'Shadow Tag', 'Wonder Guard', 'Wacky',
-		'Angel Powder + Substitute', 'Angel Powder + Protect', 'Angel Powder + Detect', 'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
+		'Abyssal Hell Drag', 'Twindeath', 'Desecrations', 'Extreme Evoboost',
 		'Cryaa', 'aaryC', 'Drizzle', 'Drought', 'Snow Warning', 'Sand Stream', 'Shadow Call', 'Acid Cloudburst', 'Thunderstorm',
 		'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 		'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 		'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-		'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Xerneas', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+		'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{


### PR DESCRIPTION
## Description
-Xerneas isn't banned
-Angel Powder complex ban changes didn't save


## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities