### PR TITLE
Another Wack ban hotfix

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -722,7 +722,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -741,7 +741,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -761,7 +761,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -781,7 +781,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -801,7 +801,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -836,7 +836,7 @@ export const Formats: FormatList = [
 		'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 		'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 		'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-		'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+		'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{
@@ -858,7 +858,7 @@ export const Formats: FormatList = [
 		'Corrupt Orb','Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie', 
 		'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 		'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-		'Hell Drag', 'Pacify', 'Rift Strike', 'Firefree', 'Furi Z', 'Nameless Demon', 'Perfect Freeze', 'Time Stasis'
+		'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis'
 		],
 	},
 	{

--- a/data/mods/wack/abilities.ts
+++ b/data/mods/wack/abilities.ts
@@ -600,6 +600,13 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		desc: "If this Pokemon originally has this ability, it changes to Zen Mode if it has 1/2 or less of its maximum HP at the end of a turn, 1/3 for Sarieangel. If the pokemon's HP is above 1/2 of its maximum HP at the end of a turn or 1/3 for Sarieangel, it changes back to Standard Mode.",
 		shortDesc: "At end of turn, changes Mode to Standard if at 1/2 max HP, else Zen.",
 	},
+	snowwarning: {
+		inherit: true,
+		onStart(source) {
+			this.field.setWeather('hail');
+		},
+		shortDesc: "On switch-in, this Pokemon summons Hail.",
+	},
 	// Gen5 vanilla abilities
 	anticipation: {
 		inherit: true,

--- a/data/mods/wack/formats-data.ts
+++ b/data/mods/wack/formats-data.ts
@@ -15562,7 +15562,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	firefree: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	pegazeus: {
@@ -16417,7 +16417,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	namelessdemon: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	darkyo: {
@@ -24537,7 +24537,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	furiz: {
 		inherit: true,
-		tier: "OU",
+		tier: "Uber",
 		isNonstandard: null,
 	},
 	furiq: {

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -72223,7 +72223,7 @@ blobbosmechelectric: {
 		weightkg: 7.5,
 		color: "Pink",
 		eggGroups: ["Fairy"],
-		battleOnly: "Cclefable"
+		battleOnly: "Cclefable",
 	},
 	elecmon: {
 		num: 668037,


### PR DESCRIPTION
I'm sorry about this third pr in less than an hour, forgot pokemon bans are handled in a different file...

## Description
-Properly added new Pokemons bans
-Updated Snow Warning to summon hail again

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities