### PR TITLE
[COPE] NO TEAM PREVIEW + TWO BANS

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -999,7 +999,6 @@ export const Formats: FormatList = [
 			'Terastal Clause',
 			'Obtainable',
 			'Dynamax Clause',
-			'Team Preview',
 			'Sleep Clause Mod',
 			'Endless Battle Clause',
 			'HP Percentage Mod',
@@ -1018,7 +1017,6 @@ export const Formats: FormatList = [
 			'Terastal Clause',
 			'Obtainable',
 			'Dynamax Clause',
-			'Team Preview',
 			'Sleep Clause Mod',
 			'Endless Battle Clause',
 			'HP Percentage Mod',
@@ -1037,7 +1035,6 @@ export const Formats: FormatList = [
 			'Terastal Clause',
 			'Obtainable',
 			'Dynamax Clause',
-			'Team Preview',
 			'Sleep Clause Mod',
 			'Endless Battle Clause',
 			'HP Percentage Mod',
@@ -1047,7 +1044,7 @@ export const Formats: FormatList = [
 			'Evasion Moves Clause',
 			'Species Clause',
 		],
-		banlist: ['AG', 'Uber', 'Baton Pass', 'Moody', 'Arena Trap', 'Shadow Tag', 'Doomsday', 'Doomsday-Revenant', 'Worldle', 'Eternal Walk', 'Cope', 'Fuck You', 'Wonder Guard', 'Wicked Blow', 'Drizzle', 'Drought'],
+		banlist: ['AG', 'Uber', 'Baton Pass', 'Moody', 'Arena Trap', 'Shadow Tag', 'Doomsday', 'Doomsday-Revenant', 'Worldle', 'Eternal Walk', 'Cope', 'Fuck You', 'Wonder Guard', 'Wicked Blow', 'Drizzle', 'Drought', 'Krackocean'],
 	},
 	///////////////////////////////////////////////////////////////////
 	// Create-a-Blobbos (CAB)

--- a/data/mods/cope/formats-data.ts
+++ b/data/mods/cope/formats-data.ts
@@ -2864,7 +2864,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	    shroomko: {
 		inherit: true,
 		isNonstandard: null,
-		tier: "OU",
+		tier: "Uber",
 	},
 	    junkbane: {
 		inherit: true,


### PR DESCRIPTION
## Description
removes team preview from COPE formats and bans krackocean and Shroomko to ubers

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities