### PR TITLE
[cope] hell

### DIFF
--- a/data/mods/cope/abilities.ts
+++ b/data/mods/cope/abilities.ts
@@ -1878,6 +1878,14 @@ export const Abilities: { [k: string]: ModdedAbilityData } = {
 	real: {
 		inherit: true,
 		isNonstandard: null,
+		},
+	goodasgold: {
+		inherit: true,
+		isNonstandard: null,
+		},
+	eartheater: {
+		inherit: true,
+		isNonstandard: null,
 	},
 	fuckforce: {
 		inherit: true,

--- a/data/mods/cope/moves.ts
+++ b/data/mods/cope/moves.ts
@@ -216,8 +216,19 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		isNonstandard: null,
 	},
 	bind: {
-		inherit: true,
-		isNonstandard: null,
+		accuracy: 85,
+		basePower: 15,
+		category: "Physical",
+		name: "Bind",
+		pp: 10,
+		priority: 0,
+		flags: {contact: 1, protect: 1, mirror: 1},
+		secondary: {
+		chance: 100,
+		volatileStatus: 'flinch',
+		target: "normal",
+		type: "Steel",
+		contestType: "Tough",
 	},
 	bite: {
 		inherit: true,

--- a/data/mods/cope/moves.ts
+++ b/data/mods/cope/moves.ts
@@ -226,6 +226,7 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		secondary: {
 		chance: 100,
 		volatileStatus: 'flinch',
+		},
 		target: "normal",
 		type: "Steel",
 		contestType: "Tough",

--- a/data/mods/cope/moves.ts
+++ b/data/mods/cope/moves.ts
@@ -228,7 +228,7 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		volatileStatus: 'flinch',
 		},
 		target: "normal",
-		type: "Steel",
+		type: "Normal",
 		contestType: "Tough",
 	},
 	bite: {


### PR DESCRIPTION
fixes a bit of stuff in the cope tier that was not properly legalized,buffs bind to be cartridge accurate

## Description
Describe what you're doing here please

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities