### PR TITLE
TOTAL SEMMUSH DEATH + minor clover tiering

### DIFF
--- a/data/mods/clover/formats-data.ts
+++ b/data/mods/clover/formats-data.ts
@@ -4245,7 +4245,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	fairileon: {
 		inherit: true,
-		tier: "OU",
+		tier: "RU",
 		isNonstandard: null,
 		randomBattleMoves: [
 			"quiverdance",
@@ -6296,7 +6296,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	regirode: {
 		inherit: true,
-		tier: "OU",
+		tier: "RU",
 		isNonstandard: null,
 		randomBattleMoves: [
 			"earthpower",
@@ -6890,7 +6890,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	dedwheat: {
 		inherit: true,
-		tier: "OU",
+		tier: "RU",
 		isNonstandard: null,
 		randomBattleMoves: [
 			"skillswap",

--- a/data/mods/clovercap/formats-data.ts
+++ b/data/mods/clovercap/formats-data.ts
@@ -49,11 +49,6 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		isNonstandard: null,
 		tier: "LC",
 	},
-	semmush: {
-		inherit: true,
-		isNonstandard: null,
-		tier: "OU",
-	},
 	starhiro: {
 		inherit: true,
 		isNonstandard: null,


### PR DESCRIPTION
semmush illegal in cap
fairileon, regirode, and dedwheat dropped back to RU where they belong (literally only one guy in OU used it enough to put it in the tier in the first place)