### PR TITLE
elemental weedle sigs full implementation

### DIFF
--- a/data/mods/cope/moves.ts
+++ b/data/mods/cope/moves.ts
@@ -4655,4 +4655,16 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	oceanhorn: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	blazingwheel: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	prisonroots: {
+		inherit: true,
+		isNonstandard: null,
+	},
 };

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -8892,6 +8892,18 @@ export const MovesText: {[k: string]: MoveText} = {
 		name: "Pantherk Kick",
 		shortDesc: "30% flinch chance. Pantherk.",
 	},
+	oceanhorn: {
+		name: "Ocean Horn",
+		shortDesc: "50% chance to flinch the opponent.",
+	},
+	blazingwheel: {
+		name: "Blazing Wheel",
+		shortDesc: "Raises the user's Speed by 1 stage. Thaws user.",
+	},
+	prisonroots: {
+		name: "Prison Roots",
+		shortDesc: "Traps and Imprisons the target.",
+	},
 	testomajesto: {
 		name: "Testo Majesto",
 		shortDesc: "'Ah, don't bother, it's just a coffee machine. Sometimes it shows ads on the screen.'",


### PR DESCRIPTION
adds the descriptions of the elemental weedle signature moves (ocean horn, blazing wheel, and prison roots)
makes all three legal in cope (though nothing actually gets them yet)