### PR TITLE
[CLOVER] 5MSS OM | [COPE] LC Buffs

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -606,6 +606,22 @@ export const Formats: FormatList = [
 		],
 	},
 	{
+		name: '[Gen 8 Clover Only] 5MSS',
+		mod: 'clover',
+		ruleset: [
+			'Terastal Clause',
+			'Standard',
+			'Dynamax Clause',
+			'Sketch Post-Gen 7 Moves',
+			'5MSS Mod',
+			'Max Move Count = 5',
+		],
+		banlist: [
+			'Uber', 'Arena Trap', 'Moody', 'Power Construct', 'Shadow Tag', 'Baton Pass', 'Wonder Guard',
+			'Condoom + Unaware', 'Potarded + Unaware', 
+		],
+	},
+	{
 		name: '[Gen 8 Clover Only] Custom Game',
 		mod: 'clover',
 		searchShow: false,

--- a/config/formats.ts
+++ b/config/formats.ts
@@ -613,7 +613,7 @@ export const Formats: FormatList = [
 			'Standard',
 			'Dynamax Clause',
 			'Sketch Post-Gen 7 Moves',
-			'5MSS Mod',
+			'Five Moveslot Syndrome Mod',
 			'Max Move Count = 5',
 		],
 		banlist: [

--- a/data/mods/cope/moves.ts
+++ b/data/mods/cope/moves.ts
@@ -2519,6 +2519,23 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 	},
 	rockwrecker: {
 		inherit: true,
+		accuracy: 100,
+		basePower: 150,
+		category: "Physical",
+		name: "Rock Wrecker",
+		pp: 5,
+		priority: 0,
+		flags: {contact: 1, protect: 1, mirror: 1},
+		self: {
+			boosts: {
+				atk: -1,
+				def: -1,
+			},
+		},
+		secondary: null,
+		target: "normal",
+		type: "Rock",
+		contestType: "Tough",
 		isNonstandard: null,
 	},
 	roleplay: {

--- a/data/mods/cope/text/moves.ts
+++ b/data/mods/cope/text/moves.ts
@@ -24,4 +24,9 @@ export const MovesText: {[k: string]: ModdedMoveText} = {
 		desc: "100% chance to make the target flinch.",
 		shortDesc: "100% chance to make the target flinch.",
 	},
+	rockwrecker: {
+		name: "Rock Wrecker",
+		desc: "Lowers the user's Attack and Defense by 1 stage.",
+		shortDesc: "Lowers the user's Attack and Defense by 1.",
+	},
 }

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1691,7 +1691,7 @@ export const Rulesets: {[k: string]: FormatData} = {
 	},
 	fivemoveslotsyndromemod: { // all this actually does is announce that it's happening. the 5 moves is allowed via config\formats.ts
 		effectType: 'Rule',
-		name: '5MSS Mod',
+		name: 'Five Moveslot Syndrome Mod',
 		desc: "Every Pok&eacute;mon's stats, barring HP, are scaled to give them a BST as close to 600 as possible",
 		onBegin() {
 			this.add('rule', '5MSS: Every Pokemon can bring up to five moves, accessible by adding a fifth move via the "Import/Export" button in the Teambuilder');

--- a/data/rulesets.ts
+++ b/data/rulesets.ts
@@ -1689,6 +1689,14 @@ export const Rulesets: {[k: string]: FormatData} = {
 			return newSpecies;
 		},
 	},
+	fivemoveslotsyndromemod: { // all this actually does is announce that it's happening. the 5 moves is allowed via config\formats.ts
+		effectType: 'Rule',
+		name: '5MSS Mod',
+		desc: "Every Pok&eacute;mon's stats, barring HP, are scaled to give them a BST as close to 600 as possible",
+		onBegin() {
+			this.add('rule', '5MSS: Every Pokemon can bring up to five moves, accessible by adding a fifth move via the "Import/Export" button in the Teambuilder');
+		},
+	},
 	teamtypepreview: {
 		effectType: 'Rule',
 		name: 'Team Type Preview',


### PR DESCRIPTION
## Description
Adds 5MSS as a Clover OM (allows for the usage of five moves per mon instead of four).
Gives Sphare and Snurl some learnset buffs.
Changes Rock Wrecker in Cope to be 150BP Rock-type Superpower.