### PR TITLE
Go-Getter + Wack garbage

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -11933,6 +11933,18 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			}
 		},
 	},
+	gogetter: {
+		name: 'Go-Getter',
+		isNonstandard: "Future",
+		isNonstandard: "Future",
+		onAfterHit(source, target, move) {
+			if (source.volatiles['mustrecharge']) {
+				source.removeVolatile('mustrecharge');
+			}
+		},
+	},
+
+
 	trickster: {
 		name: "Trickster",
 		isNonstandard: "Future",

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -529,6 +529,10 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	gogetter: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	homogeneity: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/sburbmons/abilities.ts
+++ b/data/mods/sburbmons/abilities.ts
@@ -1672,6 +1672,10 @@ export const Abilities: { [k: string]: ModdedAbilityData; } = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	gogetter: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	kantonaut: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/sweet/abilities.ts
+++ b/data/mods/sweet/abilities.ts
@@ -1584,6 +1584,10 @@ export const Abilities: { [k: string]: ModdedAbilityData; } = {
     inherit: true,
     isNonstandard: "Past"
   },
+  gogetter: {
+    inherit: true,
+    isNonstandard: "Past"
+  },
   kantonaut: {
     inherit: true,
     isNonstandard: "Past"

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -41242,8 +41242,8 @@ oceanhorn: {
 		secondary: null,
 		self: {
 			boosts: {
+				atk: -1,
 				def: -1,
-				spd: -1,
 			},
 		},
 		target: "normal",
@@ -44157,7 +44157,10 @@ beforeTurnCallback(pokemon) {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, defrost: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'brn',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -46271,6 +46274,7 @@ beforeTurnCallback(pokemon) {
 		name: "Geyser",
 		pp: 10,
 		priority: 0,
+		willCrit: true,
 		flags: {protect: 1, mirror: 1},
 		secondary: null,
 		target: "normal",
@@ -49653,6 +49657,7 @@ beforeTurnCallback(pokemon) {
 		name: "Stone Drills",
 		pp: 10,
 		priority: 0,
+		willCrit: true,
 		flags: {protect: 1, mirror: 1},
 		secondary: null,
 		target: "normal",
@@ -52528,7 +52533,10 @@ beforeTurnCallback(pokemon) {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 40,
+			status: 'psn',
+		},
 		target: "normal",
 		type: "Poison",
 		isNonstandard: "Future",
@@ -52733,6 +52741,7 @@ beforeTurnCallback(pokemon) {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		secondary: null,
+		willCrit: true,
 		target: "normal",
 		type: "Electric",
 		isNonstandard: "Future",
@@ -52951,6 +52960,11 @@ beforeTurnCallback(pokemon) {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
 		secondary: null,
+		self: {
+			boosts: {
+				spe: -1,
+			},
+		},
 		target: "normal",
 		type: "Poison",
 		isNonstandard: "Future",
@@ -53698,6 +53712,7 @@ beforeTurnCallback(pokemon) {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
+		willCrit: true,
 		target: "normal",
 		type: "Bug",
 		isNonstandard: "Future",
@@ -56839,6 +56854,7 @@ beforeTurnCallback(pokemon) {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
+		willCrit: true,
 		target: "normal",
 		type: "Grass",
 		isNonstandard: "Future",
@@ -57093,6 +57109,11 @@ beforeTurnCallback(pokemon) {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
+		basePowerCallback(pokemon, target, move) {
+			const bp = move.basePower * pokemon.hp / pokemon.maxhp;
+			this.debug('BP: ' + bp);
+			return bp;
+		},
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Ice",
@@ -65247,6 +65268,11 @@ beforeTurnCallback(pokemon) {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
+		basePowerCallback(pokemon, target, move) {
+			const bp = move.basePower * pokemon.hp / pokemon.maxhp;
+			this.debug('BP: ' + bp);
+			return bp;
+		},
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Steam",
@@ -65331,6 +65357,7 @@ beforeTurnCallback(pokemon) {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, bite: 1},
+		willCrit: true,
 		secondary: null,
 		target: "normal",
 		type: "Dark",
@@ -67559,6 +67586,11 @@ beforeTurnCallback(pokemon) {
 		name: "Fleeting Star",
 		pp: 5,
 		priority: 1,
+		basePowerCallback(pokemon, target, move) {
+			const bp = move.basePower * pokemon.hp / pokemon.maxhp;
+			this.debug('BP: ' + bp);
+			return bp;
+		},
 		flags: {protect: 1, mirror: 1},
 		secondary: null,
 		target: "allAdjacentFoes",
@@ -69975,7 +70007,12 @@ beforeTurnCallback(pokemon) {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			boosts: {
+				def: -1,
+			},
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -72012,7 +72049,10 @@ beforeTurnCallback(pokemon) {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 25,
+			status: 'par',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -72054,7 +72094,10 @@ beforeTurnCallback(pokemon) {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 25,
+			status: 'par',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -74607,6 +74650,7 @@ beforeTurnCallback(pokemon) {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
+		willCrit: true,
 		target: "normal",
 		type: "Wood",
 		isNonstandard: "Future",
@@ -74897,6 +74941,7 @@ beforeTurnCallback(pokemon) {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
+		willCrit: true,
 		target: "adjacentAllyOrSelf",
 		type: "Blood",
 		isNonstandard: "Future",

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -3195,6 +3195,11 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 		desc: "This Pokemon's moves have their secondary effect chance doubled. Foes's moves have their secondary effect chance halved.",
 		shortDesc: "Doubles user's secondary effect chances, halves foe's secondary effect chance.",
 	},
+	gogetter: {
+		name: "Go-Getter",
+		desc: "This Pokemon's recharge moves don't need to recharge.",
+		shortDesc: "This Pokemon's recharge moves don't need to recharge.",
+	},
 	masshopping: {
 		name: "Mass Hopping",
 		desc: "Hopping moves used by this Pokemon have 1.3x power.",


### PR DESCRIPTION
Go-Getter ability for sandbox
For Wack:
always crit moves:
Geyser
Stone Drills
Thunder Drill
Angle Stab
Thorn Whip
Killing Bite
Wood Pike
Slit Wrists

Cheesy Melt
Smog Shot
Bacon Rush
Honey Beam
Honeydew Blast
Villain Power
Sludge Down
Iceberg
Fleeting Star
Steam Spout

## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities