### PR TITLE
misc [CAB] and [COPE] stuff

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -9905,6 +9905,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			this.add('-ability', pokemon, 'Fake');
 		},
 		name: "Fake",
+		isPermanent: true,
 		rating: 0,
 		isNonstandard: "Future",
 	},

--- a/data/mods/cloverblobboscap/formats-data.ts
+++ b/data/mods/cloverblobboscap/formats-data.ts
@@ -3300,16 +3300,6 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		isNonstandard: null,
 		tier: "OU",
 	},
-	blobboswack: {
-		inherit: true,
-		isNonstandard: null,
-		tier: "Uber",
-	},
-	blobboswackmega: {
-		inherit: true,
-		isNonstandard: null,
-		tier: "Uber",
-	},
 	blobboscup: {
 		inherit: true,
 		isNonstandard: null,
@@ -3666,11 +3656,6 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		tier: "OU",
 	},
 	blobbosbeetle: {
-		inherit: true,
-		isNonstandard: null,
-		tier: "OU",
-	},
-	blobboskorea: {
 		inherit: true,
 		isNonstandard: null,
 		tier: "OU",

--- a/data/mods/cope/moves.ts
+++ b/data/mods/cope/moves.ts
@@ -4004,6 +4004,7 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 	},
 	yiikout: {
 		inherit: true,
+		basePower: 60,
 		isNonstandard: null,
 	},
 	roidflex: {

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -37168,7 +37168,7 @@ ttos: {
 	name: "Ttos",
 	types: ["Rock", "Dark"], // oh boy oh boy!! another rock dark!!
 	gender: 'M',
-	baseStats: {hp: 100, atk: 112, def: 95, spa: 75, spd: 88, spe: 71},
+	baseStats: {hp: 100, atk: 112, def: 109, spa: 69, spd: 88, spe: 71},
 	abilities: {0: "Sand Stream", H: "Shed Skin", S: "False Dark"},
 	heightm: 0.8,
 	weightkg: 13,

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -2845,6 +2845,10 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 		transform: "You feel an evil presence watching you!",
 		transformEnd: "Blobbos-Eye-Mouth has calmed down!",
 	},
+	codename: {
+		name: "Codename",
+		shortDesc: "+1 crit ratio; critical hit damage is boosted by 1.5x.",
+	},
 	reconstruct: {
 		name: "Reconstruct",
 		shortDesc: "Rebuilds item on switchout. Does not rebuild knocked off items.",

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -8336,6 +8336,10 @@ export const MovesText: {[k: string]: MoveText} = {
 		name: "Butterfly Kick",
 		shortDesc: "Combines Fighting in its type effectiveness.",
 	},
+	unload: {
+		name: "Unload",
+		shortDesc: "Hits 2-5 times. Applies Focus Energy to the user after the first hit.",
+	},
 	toxicbeam: {
 		name: "Toxic Beam",
 		shortDesc: "20% chance to badly poison the foe.",


### PR DESCRIPTION
## CAB
Makes Blobbos-Wack and Blobbos-Korea illegal.
Adds descriptions to Unload and Codename.

## COPE
Gives/takes away a bunch of moves to/from Meteoriik.
Re-buffs Yiik Out to 60BP.
_Definitely_ didn't buff Ttos' stats a little bit.