### PR TITLE
[COPE] THE ttos buff

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -12216,23 +12216,23 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		onSourceModifyAtkPriority: 6,
 		onSourceModifyAtk(atk, attacker, defender, move) {
 			if (move.type === 'Grass') {
-				this.debug('SEED BOMBED');
-				return this.chainModify(4);
+				this.debug('BOMB SEEDED');
+				return this.chainModify(0.5);
 			}
 			if (move.type === 'Fighting') {
-				this.debug('MACH PUNCHED');
-				return this.chainModify(4);
+				this.debug('PUNCH MACHED');
+				return this.chainModify(0.5);
 			}
 		},
 		onSourceModifySpAPriority: 5,
 		onSourceModifySpA(atk, attacker, defender, move) {
 			if (move.type === 'Grass') {
-				this.debug('GIGA DRAINED');
-				return this.chainModify(4);
+				this.debug('DRAIN GIGAD');
+				return this.chainModify(0.5);
 			}
 			if (move.type === 'Fighting') {
-				this.debug('FOCUS BLASTED');
-				return this.chainModify(4);
+				this.debug('BLAST FOCUSED');
+				return this.chainModify(0.5);
 			}
 		},
 	},

--- a/data/mods/cope/moves.ts
+++ b/data/mods/cope/moves.ts
@@ -2520,7 +2520,7 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 	rockwrecker: {
 		inherit: true,
 		accuracy: 100,
-		basePower: 150,
+		basePower: 125,
 		category: "Physical",
 		name: "Rock Wrecker",
 		pp: 5,

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -37205,7 +37205,7 @@ epipheror: {
 		name: "Ttos",
 		types: ["Rock", "Dark"], // oh boy oh boy!! another rock dark!!
 		gender: 'M',
-		baseStats: {hp: 100, atk: 112, def: 95, spa: 75, spd: 88, spe: 71},
+		baseStats: {hp: 100, atk: 112, def: 109, spa: 75, spd: 88, spe: 71},
 		abilities: {0: "Sand Stream", H: "Shed Skin", S: "False Dark"},
 		heightm: 0.8,
 		weightkg: 13,

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -3492,7 +3492,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	falsedark: {
 		name: "False Dark",
-		desc: "Like Dark, but significantly weaker to Grass and Fighting.",
+		desc: "Reduces damage taken from Grass and Fighting moves by half.",
 	},
 	musclemass: {
 		name: "Muscle Mass",


### PR DESCRIPTION
- Makes False Dark function as a real ability, now halving damage from Grass and Fighting moves.
- Gives Ttos a real learnset, as opposed to just being Gen 3 Ttar's learnset.
- Buffs Ttos' Defense from 95 to 109.
- Nerfs Rock Wrecker from 150BP to 125BP because it was kind of disgusting.