### PR TITLE
[COPE] throwback | [CAP] randbats level balance probably

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1109,6 +1109,7 @@ export const Formats: FormatList = [
 			'Species Clause',
 		],
 		banlist: ['AG', 'Baton Pass', 'Moody', 'Arena Trap', 'Shadow Tag', 'Doomsday', 'Doomsday-Revenant', 'Worldle', 'Eternal Walk', 'Cope', 'Fuck You', 'Wonder Guard'],
+		unbanlist: ['Disbeary-Ebil + Tough Claws', 'Disbeary-Ebil + Dark Aura', 'THROBAK + Wonder Guard'],
 	},
 	{
 		name: '[Gen 8 Cope Only] OU',
@@ -1128,7 +1129,7 @@ export const Formats: FormatList = [
 			'Species Clause',
 		],
 		banlist: ['AG', 'Uber', 'Baton Pass', 'Moody', 'Arena Trap', 'Shadow Tag', 'Doomsday', 'Doomsday-Revenant', 'Worldle', 'Eternal Walk', 'Fuck You', 'Wonder Guard', 'Wicked Blow', 'Drizzle', 'Drought', 'Krackocean', 'Weathervein', 'Aurora Veil', 'Maximize', "Cope + King's Rock"],
-		unbanlist: ['Disbeary-Ebil + Tough Claws', 'Disbeary-Ebil + Dark Aura'],
+		unbanlist: ['Disbeary-Ebil + Tough Claws', 'Disbeary-Ebil + Dark Aura', 'THROBAK + Wonder Guard'],
 	},
 	{
 		name: '[Gen 8 Cope Only] Flipped',

--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -8937,6 +8937,10 @@ export const FormatsData: { [k: string]: SpeciesFormatsData } = {
 		tier: "Illegal",
 		isNonstandard: "Future",
 	},
+	throbak: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
 	grandon: {
 		tier: "Illegal",
 		isNonstandard: "Future",

--- a/data/mods/clovercap/random-sets.json
+++ b/data/mods/clovercap/random-sets.json
@@ -45,7 +45,7 @@
           "aurasphere",
           "uturn"
         ],
-        "level": 84
+        "level": 77
       }
     ]
   },
@@ -70,7 +70,7 @@
           "icepunch",
           "fakeout"
         ],
-        "level": 84
+        "level": 82
       },
       {
         "abilities": [
@@ -300,7 +300,7 @@
           "highjumpkick",
           "knockoff"
         ],
-        "level": 84
+        "level": 79
       },
       {
         "abilities": [
@@ -320,7 +320,7 @@
           "megakick",
           "quickattack"
         ],
-        "level": 84
+        "level": 79
       }
     ]
   },
@@ -352,7 +352,7 @@
           "fireblast",
           "icebeam"
         ],
-        "level": 84
+        "level": 81
       },
       {
         "abilities": [
@@ -370,7 +370,7 @@
           "bravebird",
           "ironhead"
         ],
-        "level": 84
+        "level": 81
       }
     ]
   },
@@ -400,7 +400,7 @@
           "rockslide",
           "partingshot"
         ],
-        "level": 80
+        "level": 79
       },
       {
         "abilities": [
@@ -415,7 +415,7 @@
           "earthquake",
           "swordsdance"
         ],
-        "level": 80
+        "level": 79
       }
     ]
   },
@@ -511,7 +511,7 @@
           "sludgewave",
           "icebeam"
         ],
-        "level": 84
+        "level": 80
       }
     ]
   },
@@ -540,7 +540,7 @@
           "fireblast",
           "thunder"
         ],
-        "level": 84
+        "level": 80
       },
       {
         "abilities": [
@@ -558,7 +558,7 @@
           "poltergeist",
           "bravebird"
         ],
-        "level": 84
+        "level": 80
       }
     ]
   },
@@ -587,7 +587,7 @@
           "barrier",
           "rest"
         ],
-        "level": 84
+        "level": 81
       }
     ]
   },
@@ -617,7 +617,7 @@
           "swordsdance",
           "roost"
         ],
-        "level": 82
+        "level": 79
       },
       {
         "abilities": [
@@ -632,7 +632,7 @@
           "roost",
           "voltswitch"
         ],
-        "level": 82
+        "level": 79
       }
     ]
   },

--- a/data/mods/cope/formats-data.ts
+++ b/data/mods/cope/formats-data.ts
@@ -3086,6 +3086,11 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		isNonstandard: null,
 		tier: "OU",
 	},
+	throbak: {
+		inherit: true,
+		isNonstandard: null,
+		tier: "OU",
+	},
 	stoppogriff: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -37214,6 +37214,19 @@ epipheror: {
 		eggGroups: ["Monster"],
 		gen: 8,
 	},
+	throbak: { // called GHOST in coperom. name changed because lol lmao /dt would DIE
+		num: -8275,
+		name: "THROBAK",
+		types: ["Dark", "Ground"],
+		gender: 'N',
+		baseStats: {hp: 1, atk: 80, def: 1, spa: 85, spd: 85, spe: 80},
+		abilities: {0: "Wonder Guard"},
+		heightm: 1,
+		weightkg: 45,
+		color: "Purple",
+		eggGroups: ["Amorphous", "Monster"],
+		gen: 1,
+	},
 	grandon: {
 		num: -8243,
 		name: "Grandon",
@@ -37325,7 +37338,7 @@ gyonin: {
 	gen: 8,
 },
 smologre: {
-	num: -8249,
+	num: -8274,
 	name: "Smologre",
 	types: ["Ice"],
 	gender: "F",


### PR DESCRIPTION
COPE
adds THROBAK (aka GHOST)
allows THROBAK + wonder guard
changes the dex number of smologre because it was the same as raidenetti's???

CAP
lowers the levels of certain mons in randbats in an attempt to balance them (theyre probably still super fucked lol)