### PR TITLE
Bans Stink Bomb from Camomons and Removes Wack

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -543,7 +543,7 @@ export const Formats: FormatList = [
 			'Sketch Post-Gen 7 Moves',
 		],
 		banlist: [
-			'Uber', 'Arena Trap', 'Moody', 'Power Construct', 'Shadow Tag', 'Baton Pass', 'Wonder Guard',
+			'Uber', 'Arena Trap', 'Moody', 'Power Construct', 'Shadow Tag', 'Baton Pass', 'Wonder Guard', 'Stink Bomb',
 			 'Condoom + Unaware', 'Potarded + Unaware',
 		],
 	},


### PR DESCRIPTION
## Description
Describe what you're doing here please: stink bomb ban

## Checklist
- [y ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [y ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ y] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities