### PR TITLE
Illegalizes the beserk gene in CAB because WHY WAS IT LEGAL...

### DIFF
--- a/data/mods/cloverblobboscap/items.ts
+++ b/data/mods/cloverblobboscap/items.ts
@@ -115,10 +115,6 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	berserkgene: {
-		inherit: true,
-		isNonstandard: null,
-	},
 	moluganion: {
 		inherit: true,
 		onAfterSetStatusPriority: -1,

--- a/data/mods/cloverblobboscap/moves.ts
+++ b/data/mods/cloverblobboscap/moves.ts
@@ -1688,7 +1688,7 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, heal: 1},
-		drain: [3, 4],
+		drain: [1, 2],
 		secondary: null,
 		target: "normal",
 		type: "Fairy",
@@ -1740,6 +1740,12 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 	},
 	unload: {
 		inherit: true,
+		isNonstandard: null,
+	},
+		focusblast: {
+		inherit: true,
+		accuracy: 85,
+		basePower: 110,
 		isNonstandard: null,
 	},
 	finishingtouch: {


### PR DESCRIPTION
## Description
kills blobbos podoboo basically it is NOT meant to do this lmao!

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities