### PR TITLE
MORE CAB STUFF!!!!!!!!!!!!!!!!!

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1248,7 +1248,7 @@ export const Formats: FormatList = [
 			'OHKO Clause',
 			'Evasion Moves Clause',
 		],
-		banlist: ['Uber', 'Baton Pass', 'Moody', 'Arena Trap', 'Shadow Tag', 'Blobbos-Plok + Jet Punch', 'Fling + License to Sell Hotdogs', 'Mitosis Mash', 'Cell Construct', 'Power Herb + Geomancy', 'Power Herb + Awaken', 'Fishermans Ruse + Destiny Bond', 'Star Rod + Victory Dance', "Partner's Pendant + Super Snore"],
+		banlist: ['Uber', 'Baton Pass', 'Moody', 'Arena Trap', 'Shadow Tag', 'Blobbos-Plok + Jet Punch', 'Fling + License to Sell Hotdogs', 'Mitosis Mash', 'Cell Construct', 'Power Herb + Geomancy', 'Power Herb + Awaken', 'Baitite + Destiny Bond', 'Star Rod + Victory Dance', "Partner's Pendant + Super Snore"],
 	},
 	{
 		name: '[Gen 8 Clover Blobbos CAP Only] Ubers',
@@ -1268,7 +1268,7 @@ export const Formats: FormatList = [
 			'OHKO Clause',
 			'Evasion Moves Clause',
 		],
-		banlist: ['Baton Pass', 'Moody', 'Arena Trap', 'Shadow Tag', 'Fling + License to Sell Hotdogs', 'Wheygle + Unburden', 'Condoom + Unaware'],
+		banlist: ['Fling + License to Sell Hotdogs', 'Wheygle + Unburden', 'Condoom + Unaware'],
 	},
 	{
 		name: '[Gen 8 Clover Blobbos CAP Only] Doubles OU',

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -7854,7 +7854,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 	nimblemetalbody: {
 		onModifyPriority(priority, pokemon, target, move) {
 			const momentum = [
-				'batonpass', 'uturn', 'flipturn', 'partingshot', 'teleport', 'uturn', 'voltswitch', 'flashbang',
+				'batonpass', 'punchout', 'uturn', 'rockout', 'slipturn', 'backdraft', 'flipturn', 'partingshot', 'teleport', 'uturn', 'voltswitch', 'flashbang',
 			];
 			if (momentum.includes(move.id)) return priority + 1;
 		},
@@ -8275,7 +8275,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 			if (move.type === 'Fairy') {
 				return this.chainModify(0.125);
 			} else if (move.type === 'Dragon') {
-				return this.chainModify(0.25);
+				return this.chainModify(0.125);
 			}
 		},
 		onAnyEffectiveness(typemod, target, type, move) {

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -651,7 +651,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
-		regenerator: {
+	regenerator: {
 		inherit: true,
 		isNonstandard: null,
 		onSwitchOut(pokemon) {

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -509,6 +509,18 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	toxicchain: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	hospitality: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	mindseye: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	purifyingsalt: {
 		inherit: true,
 		isNonstandard: null,
@@ -620,6 +632,12 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 	thermalfumes: {
 		inherit: true,
 		isNonstandard: null,
+	},
+	regenerator: {
+		inherit: true,
+		isNonstandard: null,
+		onSwitchOut(pokemon) {
+			pokemon.heal(pokemon.baseMaxhp / 5);
 	},
 	plus: {
 		inherit: true,

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -251,8 +251,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				case 'plasticterrain':
 					newType = 'Plastic';
 					break;
-				case 'frostyterrain': 
-						newType = 'Ice';
 				}
 				if (!newType || pokemon.getTypes().join() === newType || !pokemon.setType(newType)) return;
 				this.add('-start', pokemon, 'typechange', newType, '[from] ability: Mimicry');
@@ -344,6 +342,18 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		isNonstandard: null,
 	},
 	muhmentum: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	plasticsurge: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	turbine: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	balance: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -651,12 +661,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
-	regenerator: {
-		inherit: true,
-		isNonstandard: null,
-		onSwitchOut(pokemon) {
-			pokemon.heal(pokemon.baseMaxhp / 5);
-		},
 	fireaffinity: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -757,4 +757,4 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-		}
+};

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -251,6 +251,8 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				case 'plasticterrain':
 					newType = 'Plastic';
 					break;
+				case 'frostyterrain': 
+						newType = 'Ice';
 				}
 				if (!newType || pokemon.getTypes().join() === newType || !pokemon.setType(newType)) return;
 				this.add('-start', pokemon, 'typechange', newType, '[from] ability: Mimicry');
@@ -342,18 +344,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		isNonstandard: null,
 	},
 	muhmentum: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	plasticsurge: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	turbine: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	balance: {
 		inherit: true,
 		isNonstandard: null,
 	},
@@ -661,6 +651,12 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			}
 		},
 	},
+		regenerator: {
+		inherit: true,
+		isNonstandard: null,
+		onSwitchOut(pokemon) {
+			pokemon.heal(pokemon.baseMaxhp / 5);
+		},
 	fireaffinity: {
 		inherit: true,
 		isNonstandard: null,
@@ -742,6 +738,18 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		isNonstandard: null,
 	},
 	carbonated: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	mindseye: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	hospitality: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	toxicchain: {
 		inherit: true,
 		isNonstandard: null,
 	},

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -251,6 +251,9 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 				case 'plasticterrain':
 					newType = 'Plastic';
 					break;
+				case 'frostyterrain':
+					newType = 'Ice';
+					break;
 				}
 				if (!newType || pokemon.getTypes().join() === newType || !pokemon.setType(newType)) return;
 				this.add('-start', pokemon, 'typechange', newType, '[from] ability: Mimicry');

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -757,4 +757,4 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-};
+}

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -636,6 +636,14 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	regenerator: {
+		onSwitchOut(pokemon) {
+			pokemon.heal(pokemon.baseMaxhp / 5);
+		},
+		name: "Regenerator",
+		rating: 4.5,
+		num: 144,
+	},
 	plus: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -633,12 +633,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	regenerator: {
-		inherit: true,
-		isNonstandard: null,
-		onSwitchOut(pokemon) {
-			pokemon.heal(pokemon.baseMaxhp / 5);
-	},
 	plus: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -741,18 +741,6 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-	mindseye: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	hospitality: {
-		inherit: true,
-		isNonstandard: null,
-	},
-	toxicchain: {
-		inherit: true,
-		isNonstandard: null,
-	},
 	windpower: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/cloverblobboscap/abilities.ts
+++ b/data/mods/cloverblobboscap/abilities.ts
@@ -757,4 +757,4 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		inherit: true,
 		isNonstandard: null,
 	},
-}
+		}

--- a/data/mods/cloverblobboscap/moves.ts
+++ b/data/mods/cloverblobboscap/moves.ts
@@ -1158,6 +1158,30 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	hydrosteam: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	psyblade: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	bloodmoon: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	syrupbomb: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	ivycudgel: {
+		inherit: true,
+		isNonstandard: null,
+	},
+	matchagotcha: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	laserbeam: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/cloverblobboscap/text/abilities.ts
+++ b/data/mods/cloverblobboscap/text/abilities.ts
@@ -4,6 +4,11 @@ export const AbilitiesText: {[k: string]: ModdedAbilityText} = {
 		desc: "If an active ally has this Ability or the Minus Ability, this Pokemon's Special Attack is multiplied by 1.5. After an Electric-type move hits, has a 25% chance to boost a random stat (not acc/eva).",
 		shortDesc: "If an active ally has this Ability or the Minus Ability, this Pokemon's Sp. Atk is 1.5x. After an Electric-type move hits, has a 25% chance to boost a random stat (not acc/eva).",
 	},
+	regenerator: {
+		name: "Regenerator",
+		desc: "When the holder of this ability is switched out, 20% of their current max hp is recovered.",
+		shortDesc: "This Pokemon restores 1/5 of its maximum HP when its switched out.",
+	},
 	minus: {
 		name: "Minus",
 		desc: "If an active ally has this Ability or the Plus Ability, this Pokemon's Special Attack is multiplied by 1.5. Prevents this Pokemon's stats from being lowered.",

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -25552,7 +25552,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {bite: 1, contact: 1, protect: 1, mirror: 1},
 		onHit(target, source) {
-			if (target && target.hasType('Steel')) {
+			if (target.getTypes().includes('Steel')) {
 				target.trySetStatus('brn', source);
 			}
 		},

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -33178,7 +33178,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		onTry(source, target) {
 			if (!target.side.addSlotCondition(target, 'futuremove')) return false;
 			Object.assign(target.side.slotConditions[target.position]['futuremove'], {
-				duration: 3,
+				duration: 4,
 				move: 'scryingwish',
 				source: source,
 				moveData: {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -25552,7 +25552,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {bite: 1, contact: 1, protect: 1, mirror: 1},
 		onHit(target, source) {
-			if (target.getTypes().includes('Steel')) {
+			if (target && target.hasType('Steel')) {
 				target.trySetStatus('brn', source);
 			}
 		},

--- a/data/text/moves.ts
+++ b/data/text/moves.ts
@@ -7972,12 +7972,12 @@ export const MovesText: {[k: string]: MoveText} = {
 	nuclearwinter: {
 		name: "Nuclear Winter",
 		desc: "Has a 10% chance to freeze the target. This move's type effectiveness against Poison is changed to be super effective no matter what this move's type is. If the weather is Hail, this move does not check accuracy.",
-		shortDesc: "10% chance to freeze. Super effective on Poison.",
+		shortDesc: "10% chance to freeze. Super effective on Poison. Cannot miss under Hail or Snow.",
 	},
 	badeggs: {
 		name: "Bad Eggs",
 		desc: "Hits three times. Power increases to 40 for the second hit and 60 for the third. This move checks accuracy for each hit, and the attack ends if the target avoids a hit. If one of the hits breaks the target's substitute, it will take damage for the remaining hits. If the user has the Skill Link Ability, this move will always hit three times. Each hit has a 10% chance to poison the target.",
-		shortDesc: "Hits 3 times, hits can miss, gets stronger, 10% psn.",
+		shortDesc: "Hits 3 times. Each hit can miss and gets stronger per hit. 10% psn.",
 	},
 	backdraft: {
 		name: "Backdraft",


### PR DESCRIPTION
## Description
nerfs blobbos scrying  
kills cab ubers because it sounds funny 
mega bait blobbos also gets kinda killed 
legalizes DLC 1 moves and abilities in cab for the future
changes regen in cab
mimicry actually functions with frosty terrain whoa
ignore me trying to fix flint fang it was already fixed lole

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities