### PR TITLE
ACTUALLY illegalizes hidden powre in copedraft

### DIFF
--- a/data/mods/cope/abilities.ts
+++ b/data/mods/cope/abilities.ts
@@ -679,6 +679,10 @@ export const Abilities: { [k: string]: ModdedAbilityData } = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	quarkdrive: {
+		inherit: true,
+		isNonstandard: null,
+	},
 	queenlymajesty: {
 		inherit: true,
 		isNonstandard: null,

--- a/data/mods/copedraft/moves.ts
+++ b/data/mods/copedraft/moves.ts
@@ -1466,6 +1466,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: null,
 	},
+	hiddenpower: {
+		inherit: true,
+		isNonstandard: "Future",
+	},
 	highhorsepower: {
 		inherit: true,
 		isNonstandard: null,


### PR DESCRIPTION
hidden power is legal by default so it has to be made illegal specifically in cope draft