### PR TITLE
baton pass is now just a regular pivot move in draft

### DIFF
--- a/data/mods/copedraft/moves.ts
+++ b/data/mods/copedraft/moves.ts
@@ -180,8 +180,25 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		isNonstandard: null,
 	},
 	batonpass: {
-		inherit: true,
-		isNonstandard: null,
+		num: 226,
+		accuracy: true,
+		basePower: 0,
+		category: "Status",
+		name: "Baton Pass",
+		pp: 40,
+		priority: 0,
+		flags: {},
+		onTry(source) {
+			return !!this.canSwitch(source.side);
+		},
+		selfSwitch: true,
+		secondary: null,
+		target: "self",
+		type: "Normal",
+		zMove: {effect: 'heal'},
+		contestType: "Cool",
+		desc: "User switches out.",
+		shortDesc: "User swiches out.",
 	},
 	beakblast: {
 		inherit: true,


### PR DESCRIPTION
## Description
the user switches

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities