### PR TITLE
CAP Ranbats: E-G

### DIFF
--- a/data/mods/clovercap/random-sets.json
+++ b/data/mods/clovercap/random-sets.json
@@ -1107,6 +1107,188 @@
       }
     ]
   },
+     "eccosmic": {
+    "nicknames": [
+      "Eccosmic",
+      "Eccosmic",
+      "Eccosmic",
+      "Eccosmic",
+      "Eccosmic",
+      "Eccosmic",
+      "Eccosmic",
+      "Eccosmic",
+      "Eccosmic",
+      "Phindolph",
+      "Rude",
+      "Eepy Cozy"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "regenerator"
+        ],
+        "items": [
+          "leftovers",
+          "rockyhelmet"
+        ],
+        "lockedMoves": [
+          "lusterpurge",
+          "scald",
+          "stealthrock",
+          "flipturn"
+        ],
+        "level": 80
+      },
+      {
+        "abilities": [
+          "serenegrace"
+        ],
+        "items": [
+          "lifeorb",
+          "leftovers"
+        ],
+        "moves": [
+          "recover",
+          "stealthrock",
+        ],
+        "lockedMoves": [
+          "moonblast",
+          "scald",
+          "psychic"
+        ],
+        "level": 80
+      }
+    ]
+  },
+    "emojinn": {
+    "nicknames": [
+      "Emojinn",
+      "Emojinn",
+      "Emojinn",
+      "Emojinn",
+      "Emojinn",
+      "Emojinn",
+      "Will Smith",
+      "ROFL XD"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "prankster"
+        ],
+        "items": [
+          "lightclay",
+        ],
+        "lockedMoves": [
+          "lightscreen",
+          "reflect",
+          "partingshot",
+          "moonlight"
+        ],
+        "level": 84
+      },
+      {
+        "abilities": [
+          "aerilate"
+        ],
+        "items": [
+          "lifeorb",
+          "skyplate"
+        ],
+        "moves": [
+          "heatwave",
+          "powergem",
+          "aurasphere",
+          "dazzlinggleam",
+          "focusblast"
+        ],
+        "lockedMoves": [
+          "hypervoice",
+          "photongeyser",
+          "nastyplot"
+        ],
+        "level": 84
+      }
+    ]
+  },
+   "equuan": {
+    "nicknames": [
+      "Equuan",
+      "Equuan",
+      "Equuan",
+      "How Hungry"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "striker"
+        ],
+        "items": [
+          "choiceband",
+          "lifeorb"
+        ],
+        "moves": [
+          "blazekick",
+          "tropkick",
+          "uturn"
+        ],
+        "lockedMoves": [
+          "megakick",
+          "tripleaxel",
+          "highjumpkick"
+        ],
+        "level": 78
+      }
+    ]
+  },
+   "erochre": {
+    "nicknames": [
+      "Erochre",
+      "Erochre",
+      "Erochre",
+      "Erochre",
+      "Erochre",
+      "Erochre",
+      "Erover",
+      "Mediochre"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "sandstream"
+        ],
+        "items": [
+          "smoothrock",
+        ],
+        "lockedMoves": [
+          "mirageveil",
+          "shoreup",
+          "stealthrock",
+          "erosionwave"
+        ],
+        "level": 88
+      },
+      {
+        "abilities": [
+          "filter"
+        ],
+        "items": [
+          "leftovers",
+          "weaknesspolicy"
+        ],
+        "moves": [
+          "heatwave",
+          "surf",
+        ],
+        "lockedMoves": [
+          "irondefense",
+          "bodypress",
+          "erosionwave",
+        ],
+        "level": 88
+      }
+    ]
+  },
   "empidae": {
     "nicknames": [
       "Empidae",

--- a/data/mods/clovercap/random-sets.json
+++ b/data/mods/clovercap/random-sets.json
@@ -1339,6 +1339,59 @@
       }
     ]
   },
+    "flarhea": {
+    "nicknames": [
+      "Flarhea",
+      "Flarhea",
+      "Flarhea",
+      "Flarhea",
+      "Flarhea",
+      "Flarhea",
+      "Flahjita",
+      "Heatah"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "reckless"
+        ],
+        "items": [
+          "choiceband",
+          "sitrusberry",
+        ],
+        "moves": [
+          "uturn",
+          "braindamage",
+          "bravebird"
+        ],
+        "lockedMoves": [
+          "volttackle",
+          "flareblitz",
+          "highjumpkick"
+        ],
+        "level": 83
+      },
+      {
+        "abilities": [
+          "striker",
+        ],
+        "items": [
+          "lifeorb",
+          "choiceband"
+        ],
+        "moves": [
+          "uturn",
+          "earthquake",
+        ],
+        "lockedMoves": [
+          "blazekick",
+          "highjumpkick",
+          "crashhopper"
+        ],
+        "level": 83
+      }
+    ]
+  },
   "forgotno": {
     "nicknames": [
       "FORGOTNO",
@@ -1386,6 +1439,164 @@
           "ironhead"
         ],
         "level": 81
+      }
+    ]
+  },
+   "frozweed": {
+    "nicknames": [
+      "Frozweed",
+      "Frozweed",
+      "Frozweed",
+      "dude weed lmao"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "magicguard"
+        ],
+        "items": [
+          "focussash"
+        ],
+        "moves": [
+          "earthpower",
+          "flamethrower"
+        ],
+        "lockedMoves": [
+          "toke",
+          "energyball",
+          "icebeam"
+        ],
+        "level": 87
+      }
+    ]
+  },
+     "fucker": {
+    "nicknames": [
+      "Fucker",
+      "Fucker",
+      "Fucker",
+      "Fucker",
+      "Fucker",
+      "Fucker",
+      "Fucker",
+      "Fucker",
+      "Fucker",
+      "Wife Beater",
+      "Fuck You",
+      "Fuck Yourself"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "scrappy",
+          "ironfist"
+        ],
+        "items": [
+          "luckypunch",
+          "lifeorb",
+          "choiceband"
+        ],
+         "moves": [
+          "suckerpunch",
+          "thunderpunch",
+          "bravebird",
+          "icepunch",
+          "gunkshot"
+        ],
+        "lockedMoves": [
+          "rocketpunch",
+          "punchout",
+          "closecombat"
+        ],
+        "level": 88
+      }
+    ]
+  },
+    "fungnet": {
+    "nicknames": [
+      "Fungnet",
+      "Fungnet",
+      "Fungnet",
+      "Fungnet",
+      "Fungnet",
+      "Fungnet",
+      "Fungnet",
+      "Fungnet",
+      "Fungnet",
+      "Funger",
+      "Stichface",
+      "PvZ"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "illuminate"
+        ],
+        "items": [
+          "leftovers"
+        ],
+         "moves": [
+          "sleeppowder",
+          "leechseed",
+        ],
+        "lockedMoves": [
+          "thunder",
+          "gigadrain",
+          "voltswitch"
+        ],
+        "level": 82
+         {
+        "abilities": [
+          "poisonheal"
+        ],
+        "items": [
+          "toxicorb"
+        ],
+        "lockedMoves": [
+          "protect",
+          "thundercage",
+          "spore",
+          "gigadrain"
+        ],
+        "level": 82
+      }
+    ]
+  },
+   "fusjahl": {
+    "nicknames": [
+      "Fusjahl",
+      "Fusjahl",
+      "Fusjahl",
+      "Fusjahl",
+      "Fusjahl",
+      "Fusjahl",
+      "El Memes",
+      "Disabled Guys"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "overeager"
+        ],
+        "items": [
+          "leftovers",
+          "choiceband",
+          "sitrusberry"
+        ],
+        "moves": [
+          "mudslap",
+          "rocktomb",
+          "flamecharge",
+          "fruitpunch",
+          "icepunch",
+          "poisonjab",
+          "lunge"
+        ],
+        "lockedMoves": [
+          "memepunch",
+          "earthquake"
+        ],
+        "level": 88
       }
     ]
   },

--- a/data/mods/clovercap/random-sets.json
+++ b/data/mods/clovercap/random-sets.json
@@ -1600,6 +1600,352 @@
       }
     ]
   },
+    "galvadeux": {
+    "nicknames": [
+      "Galvadeux",
+      "Galvadeux",
+      "Galvadeux",
+      "HEAVY LOBSTER"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "intimidate",
+          "teravolt",
+          "pressure"
+        ],
+        "items": [
+          "leftovers",
+          "rockyhelmet",
+        ],
+        "moves": [
+          "toxic",
+          "defog",
+          "knockoff"
+        ],
+        "lockedMoves": [
+          "plasmafists",
+          "uturn",
+          "roost"
+        ],
+        "level": 79
+      }
+    ]
+  },
+    "gargarramer": {
+    "nicknames": [
+      "Gargarramer",
+      "Gargarramer",
+      "Gargarramer",
+      "Gargarramer",
+      "Gargarramer",
+      "Gargarramer",
+      "Gamer",
+      "Good Goyle",
+      "Petrification"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "stoneflesh"
+        ],
+        "items": [
+          "leftovers",
+          "lifeorb",
+          "sitrusberry"
+        ],
+        "lockedMoves": [
+          "bravebird",
+          "accelerock",
+          "petrify",
+          "stoneedge"
+        ],
+        "level": 83
+      },
+      {
+        "abilities": [
+          "stoneflesh"
+        ],
+        "items": [
+          "lifeorb",
+          "leftovers",
+          "sitrusberry"
+        ],
+         "moves": [
+          "flamethrower",
+          "earthshatter",
+          "earthpower",
+          "airslash"
+        ],
+        "lockedMoves": [
+          "nastyplot",
+          "petrify",
+          "powergem"
+        ],
+        "level": 83
+      }
+    ]
+  },
+   "ghastropod": {
+    "nicknames": [
+      "Ghastropod",
+      "Ghastropod",
+      "Ghastropod",
+      "Ghastropod",
+      "Ghastropod",
+      "Ghastropod",
+      "ACID!!!",
+      "Sussy Ghussy",
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "purifyingsalt",
+          "dryskin"
+        ],
+        "items": [
+          "leftovers"
+        ],
+        "moves": [
+          "stealthrock",
+          "bodypress",
+          "powergem",
+          "earthpower"
+        ],
+        "lockedMoves": [
+          "recover",
+          "willowisp",
+          "hex"
+        ],
+        "level": 80
+      },
+      {
+        "abilities": [
+          "purifyingsalt",
+          "dryskin"
+        ],
+        "items": [
+          "lifeorb",
+          "focussash",
+          "whiteherb"
+        ],
+         "moves": [
+          "bugbuzz",
+          "icebeam",
+          "earthpower",
+          "gigadrain",
+          "hydropump"
+        ],
+        "lockedMoves": [
+          "shellsmash",
+          "shadowball",
+          "powergem"
+        ],
+        "level": 80
+      }
+    ]
+  },
+   "gigapuddi": {
+    "nicknames": [
+      "Gigapuddi",
+      "Gigapuddi",
+      "Gigapuddi",
+      "Gigapuddi",
+      "Gigapuddi",
+      "Gigapuddi",
+      "Sweet Tooth",
+      "Gluttony"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "beastboost"
+        ],
+        "items": [
+          "leftovers"
+        ],
+        "lockedMoves": [
+          "dazzlinggleam",
+          "storedpower",
+          "calmmind",
+          "milkdrink"
+        ],
+        "level": 79
+      },
+      {
+        "abilities": [
+          "aromaveil",
+          "sweetveil"
+        ],
+        "items": [
+          "leftovers"
+        ],
+        "lockedMoves": [
+          "teleport",
+          "dazzlinggleam",
+          "milkdrink",
+          "thunderbolt"
+        ],
+        "level": 79
+      }
+    ]
+  },
+   "ginocchio": {
+    "nicknames": [
+      "Ginocchio",
+      "Ginocchio",
+      "Ginocchio",
+      "Ginocchio",
+      "Ginocchio",
+      "Ginocchio",
+      "Fat Tits",
+      "Forest Maze"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "technician"
+        ],
+        "items": [
+          "lifeorb",
+          "loadeddice"
+        ],
+         "moves": [
+          "rocketpunch",
+          "cherrybomb",
+          "speedweed"
+        ],
+        "lockedMoves": [
+          "starseedblast",
+          "bulletseed"
+        ],
+        "level": 83
+      },
+      {
+        "abilities": [
+          "skilllink"
+        ],
+        "items": [
+          "lifeorb",
+          "kingsrock"
+        ],
+         "moves": [
+          "barrage",
+          "secretsword",
+          "airslash",
+          "partingshot"
+        ],
+        "lockedMoves": [
+          "bulletseed",
+          "starseedshot"
+        ],
+        "level": 83
+      }
+    ]
+  },
+  "glaciun": {
+    "nicknames": [
+      "Glaciun",
+      "Glaciun",
+      "Glaciun",
+      "Glaciun",
+      "Glaciun",
+      "Glaciun",
+      "Stag",
+      "Rink King"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "technician"
+        ],
+        "items": [
+          "lifeorb"
+        ],
+        "lockedMoves": [
+          "iceshard",
+          "tripleaxel",
+          "fellstinger",
+          "firstimpression"
+        ],
+        "level": 79
+      },
+      {
+        "abilities": [
+          "technician"
+        ],
+        "items": [
+          "lifeorb",
+          "choiceband"
+        ],
+         "moves": [
+          "swordsdance",
+          "firstimpression",
+          "crashhopper",
+          "knockoff"
+        ],
+        "lockedMoves": [
+          "glaciallance",
+          "iceshard",
+          "earthquake"
+        ],
+        "level": 79
+      }
+    ]
+  },
+   "glucurs": {
+    "nicknames": [
+      "Glucurs",
+      "Glucurs",
+      "Glucurs",
+      "Glucurs",
+      "Glucurs",
+      "Glucurs",
+      "Sour Bear",
+      "Mega Mogus Jr."
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "toxicboost"
+        ],
+        "items": [
+          "toxicorb"
+        ],
+         "moves": [
+          "knockoff",
+          "ironhead",
+          "machpunch"
+        ],
+        "lockedMoves": [
+          "protect",
+          "playrough",
+          "closecombat"
+        ],
+        "level": 88
+      },
+      {
+        "abilities": [
+          "triage"
+        ],
+        "items": [
+          "lifeorb",
+          "leftovers",
+          "bigroot"
+        ],
+         "moves": [
+          "pixiepummel",
+          "playrough"
+        ],
+        "lockedMoves": [
+          "leechlife",
+          "honeclaws",
+          "drainpunch"
+        ],
+        "level": 88
+      }
+    ]
+  },
   "ignifatu": {
     "nicknames": [
       "Ignifatu",
@@ -1608,6 +1954,10 @@
       "Ignifatu",
       "Ignifatu",
       "Ignifatu",
+      "Ignifatu",
+      "Ignifatu",
+      "Ignifatu",
+      "WRATH",
       "FIREBRINGER",
       "UNEXPECTANCY",
       "COÑO!!!!"


### PR DESCRIPTION
## Description
provides clovercap ranbat sets for every mon from E-G
## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities