### PR TITLE
More Wackslop for the POWERWACKERS

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1003,6 +1003,22 @@ export const Formats: FormatList = [
 		team: 'random',
 		ruleset: ['Terastal Clause', 'Dynamax Clause', 'Obtainable', 'HP Percentage Mod', 'Cancel Mod'],
 	},
+	{
+		name: '[Gen 8 Wack Only] Pick Your Team Random Battle',
+		mod: 'wack',
+		team: 'random',
+		gameType: 'freeforall',
+		ruleset: ['Terastal Clause', 'Sleep Clause Mod', 'Picked Team Size = 6', 'Max Team Size = 12', 'Team Preview', 'Dynamax Clause', 'Obtainable', 'HP Percentage Mod', 'Cancel Mod'],
+	},
+	{
+		name: '[Gen 8 Wack Only] FFA Random Battle',
+		mod: 'wack',
+		team: 'random',
+		gameType: 'freeforall',
+		tournamentShow: false,
+		rated: false,
+		ruleset: ['Terastal Clause', 'Dynamax Clause', 'Obtainable', 'Species Clause', 'HP Percentage Mod', 'Cancel Mod', 'Sleep Clause Mod'],
+	},
 	///////////////////////////////////////////////////////////////////
 	// Wack OMs
 	///////////////////////////////////////////////////////////////////

--- a/data/mods/wack/moves.ts
+++ b/data/mods/wack/moves.ts
@@ -665,7 +665,35 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	aquaring: {
 		inherit: true,
+		
+		accuracy: true,
+		basePower: 0,
+		category: "Status",
+		name: "Aqua Ring",
+		pp: 20,
+		priority: 0,
 		flags: {snatch: 1, heal: 1},
+		volatileStatus: 'aquaring',
+		condition: {
+			onStart(pokemon) {
+				this.add('-start', pokemon, 'Aqua Ring');
+			},
+			onModifyDefPriority: 10,
+			onModifyDef(spd, pokemon) {
+				if (this.field.getPseudoWeather('coralreef')) {
+					return this.chainModify([1.5]);
+				}
+			},
+			onResidualOrder: 6,
+			onResidual(pokemon) {
+				this.heal(pokemon.baseMaxhp / 16);
+			},
+		},
+		secondary: null,
+		target: "self",
+		type: "Water",
+		zMove: {boost: {def: 1}},
+		contestType: "Beautiful",
 		isNonstandard: null,
 	},
 	aquatail: {
@@ -4397,8 +4425,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			pp: 5,
 			priority: 0,
 			flags: {contact: 1, recharge: 1, protect: 1, mirror: 1},
-			self: {
-				volatileStatus: 'mustrecharge',
+			onAfterHit(target, source) {
+				if (target && target.hp) {
+					source.addVolatile('mustrecharge');
+				}
 			},
 			secondary: null,
 			target: "normal",
@@ -4535,8 +4565,10 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 			pp: 5,
 			priority: 0,
 			flags: {contact: 1, recharge: 1, protect: 1, mirror: 1},
-			self: {
-				volatileStatus: 'mustrecharge',
+			onAfterHit(target, source) {
+				if (target && target.hp) {
+					source.addVolatile('mustrecharge');
+				}
 			},
 			secondary: null,
 			target: "normal",

--- a/data/mods/wack/random-sets.json
+++ b/data/mods/wack/random-sets.json
@@ -253,6 +253,113 @@
       }
     ]
   },
+  "betalapras": {
+    "nicknames": [
+      "Beta Lapras"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "waterabsorb",
+          "drizzle"
+        ],
+        "items": [
+          "lifeorb",
+          "angelpowder",
+          "heavydutyboots"
+        ],
+        "moves": [
+          "cooldown",
+          "mysticdance",
+          "thunderbolt",
+          "soulchill",
+          "sonar"
+        ],
+        "lockedMoves": [
+          "freezingwave"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "bewdragon": {
+    "nicknames": [
+      "Blue Eyes"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "pressure",
+          "roughskin"
+        ],
+        "items": [
+          "lifeorb",
+          "angelpowder",
+          "dracoplate"
+        ],
+        "moves": [
+          "shimmerstrike",
+          "chargebeam",
+          "lenience"
+        ],
+        "lockedMoves": [
+          "burststream"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "bloodoom": {
+    "nicknames": [
+      "Bloodoom"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "hydration",
+          "cursedbody"
+        ],
+        "items": [
+          "lifeorb",
+          "angelpowder",
+          "heavydutyboots"
+        ],
+        "moves": [
+          "hex",
+          "scald",
+          "sludgebomb"
+        ],
+        "lockedMoves": [
+          "bloodbpump"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "carmillapire": {
+    "nicknames": [
+      "Carmillapire"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "siphon"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [
+          "bloodsiphon",
+          "gigadrain",
+          "vampirebite"
+        ],
+        "lockedMoves": [
+          "bloodbite"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "cheezipake": {
     "nicknames": [
       "Cheezipake"
@@ -299,6 +406,32 @@
         ],
         "lockedMoves": [
           "invasion"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "corsola": {
+    "nicknames": [
+      "corsola"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "naturalcure"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [
+          "rest",
+          "stealthrock",
+          "rockgather",
+          "scald"
+        ],
+        "lockedMoves": [
+          "coralreef",
+          "powergem"
         ],
         "level": 84
       }
@@ -561,7 +694,7 @@
         "moves": [
           "lubricate",
           "oilskin",
-          "oilytrrain",
+          "oilyterrain",
           "earthquake",
           "painsplit"
         ],
@@ -667,6 +800,32 @@
         ],
         "lockedMoves": [
           "chaosbolt"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "mcorsola": {
+    "nicknames": [
+      "Mega-Corsola"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "graze"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [
+          "stealthrock",
+          "rockgather",
+          "earthpower",
+          "scald"
+        ],
+        "lockedMoves": [
+          "coralreef",
+          "powergem"
         ],
         "level": 84
       }
@@ -779,7 +938,32 @@
     ]
   },
  
-  
+  "reeficoral": {
+    "nicknames": [
+      "Reeficoral"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "oblivious"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [
+          "coralgraze",
+          "curse",
+          "firewhip",
+          "knockoff"
+        ],
+        "lockedMoves": [
+          "coralreef",
+          "coralbomb"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "regifight": {
     "nicknames": [
       "Regifight"
@@ -823,6 +1007,32 @@
           "hurricane"
         ],
         "level": 72
+      }
+    ]
+  },
+  "rogyst": {
+    "nicknames": [
+      "Rogyst"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "filter"
+        ],
+        "items": [
+          "leftovers"
+        ],
+        "moves": [
+          "autotomize",
+          "fossilize",
+          "ironhead",
+          "hammerarm"
+        ],
+        "lockedMoves": [
+          "crystaledge",
+          "stoneedge"
+        ],
+        "level": 84
       }
     ]
   },
@@ -1419,7 +1629,7 @@
         ],
         "lockedMoves": [
           "driveby",
-          "justticecrash"
+          "justicecrash"
         ],
         "level": 84
       }
@@ -1563,6 +1773,83 @@
       }
     ]
   },
+  "conix": {   
+     "nicknames": [   
+      "The blue wall",
+      "Onix but good"
+    ],
+    "sets": [
+      {
+        "abilities": [    
+          "rockhead",
+          "sturdy"
+        ],
+        "items": [
+          "eviolite",    
+          "angelpowder"
+        ],
+        "moves": [     
+          "rest",
+          "coil",
+          "crystalize",
+          "gravityshift",
+          "cavein",
+          "stealthrock",
+          "doubleedge",
+          "earthquake"
+        ],
+        "lockedMoves": [   
+          "crystaledge"
+        ],
+        "level": 84        
+      },
+      {
+        "abilities": [
+          "sturdy"
+        ],
+        "items": [
+          "eviolite"    
+        ],
+        "lockedMoves": [
+          "dragontail",
+          "coil",
+          "waterfall",
+          "crystaledge"
+        ],
+        "level": 84        
+      },
+     {
+        "abilities": [
+          "sturdy"
+        ],
+        "items": [
+          "eviolate"    
+        ],
+        "lockedMoves": [
+          "crystaledge",
+          "crystalize",
+          "waterfall",
+          "earthquake"
+        ],
+        "level": 84        
+      }, 
+     {
+        "abilities": [
+          "sturdy"
+        ],
+        "items": [
+          "eviolite"    
+        ],
+        "lockedMoves": [
+          "solidify",
+          "toxic",
+          "rest",
+          "crystalslide"
+        ],
+        "level": 84        
+      } 
+    ]
+  }, 
   "archville": {
     "nicknames": [
       "Archville"
@@ -1585,6 +1872,140 @@
         ],
         "lockedMoves": [
           "summonundead"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "hyonix": {   
+    "sets": [
+      {
+        "abilities": [   
+          "poisonpoint",
+          "sturdy"
+        ],
+        "items": [
+          "angel powder",
+          "eviolite",
+          "eviolate",
+          "eviocicle"
+        ],
+        "moves": [     
+          "iron head",    
+          "scrapmetal",
+          "stealthrock",
+          "coil",
+          "stoneedge",
+          "dragontail",
+          "earthquake",
+          "toxic"
+        ],
+        "lockedMoves": [
+          "irontail"
+        ],
+        "level": 84       
+      }
+    ]
+  }, 
+  "exeggutor": {   
+     "nicknames": [   
+      "infernum",
+      "eggman"
+    ],
+    "sets": [
+      {
+        "abilities": [    
+          "harvest"
+        ],
+        "items": [
+          "sitrusberry",    
+          "apicotberry",
+          "starfberry"
+        ],
+        "moves": [     
+          "calm mind",
+          "gigadrain",
+          "softboiled",
+          "sleeppowder",
+          "psychic",
+          "lightscreen",
+          "sunnyday",
+          "explosion"
+        ],
+        "lockedMoves": [   
+          "leechseed"
+        ],
+        "level": 84        
+      },
+      {
+        "abilities": [
+          "harvest"
+        ],
+        "items": [
+          "lumberry"    
+        ],
+        "lockedMoves": [
+          "rest",
+          "sunnyday",
+          "gigadrain",
+          "psychic"
+        ],
+        "level": 84        
+      }   
+    ]
+  },
+  "huonix": {   
+     "nicknames": [   
+      "coonix"
+    ],
+    "sets": [
+      {
+        "abilities": [   
+          "weakarmor",
+          "sturdy"
+        ],
+        "items": [
+          "choiceband",
+          "mercuryorb",
+          "angelpowder",
+          "choicescarf"
+        ],
+        "moves": [     
+          "slingshot",    
+          "flintstrike",
+          "iron tail",
+          "cbt",
+          "stoneedge",
+          "coil"
+        ],
+        "lockedMoves": [
+          "earthquake"
+        ],
+        "level": 84       
+      }
+    ]
+  },
+  "jcursola": {
+    "nicknames": [
+      "Jcursola"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "naturalcure"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [
+          "rest",
+          "stealthrock",
+          "rockgather",
+          "scald"
+        ],
+        "lockedMoves": [
+          "coralreef",
+          "powergem"
         ],
         "level": 84
       }
@@ -1709,6 +2130,34 @@
       }
     ]
   },
+  "onix": {   
+    "sets": [
+      {
+        "abilities": [   
+          "weakarmor",
+          "sturdy"
+        ],
+        "items": [
+          "eviolite",
+          "martianorb",
+          "eviolate",
+          "eviocicle"
+        ],
+        "moves": [     
+          "slingshot",    
+          "flintstrike",
+          "iron head",
+          "crystalize",
+          "stealthrock"
+        ],
+        "lockedMoves": [
+          "whet",
+          "precipiceblades"
+        ],
+        "level": 84       
+      }
+    ]
+  },
   "paperbowser": {
     "nicknames": [
       "Paper Bowser"
@@ -1785,33 +2234,7 @@
       }
     ]
   },
-  "whitehand": {
-    "nicknames": [
-      "White Hand"
-    ],
-    "sets": [
-      {
-        "abilities": [
-          "souleater"
-        ],
-        "items": [
-          "lifeorb",
-          "heavydutyboots",
-          "angelpowder"
-        ],
-        "moves": [
-          "brutal",
-          "painsplit",
-          "ghastlyhand",
-          "shadowclaw"
-        ],
-        "lockedMoves": [
-          "fist"
-        ],
-        "level": 84
-      }
-    ]
-  },
+  
   "skeleton": {
     "nicknames": [
       "Skeleton"
@@ -1831,6 +2254,32 @@
           "throatchop"
         ],
         
+        "level": 84
+      }
+    ]
+  },
+  "skulloton": {
+    "nicknames": [
+      "Skulloton"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "prankster"
+        ],
+        "items": [
+          "shatteringhammer"
+        ],
+        "moves": [
+          "machpunch",
+          "bonecrusher",
+          "knockoff",
+          "geargrind",
+          "uturn"
+        ],
+        "lockedMoves": [
+          "bonemerang"
+        ],
         "level": 84
       }
     ]
@@ -2157,6 +2606,83 @@
       }
     ]
   },
+  "standobadcompany": {
+    "nicknames": [
+      "Bad Company"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "skilllink"
+        ],
+        "items": [
+          "shatteringhammer"
+        ],
+        "moves": [
+          "bulletseed",
+          "iciclespear",
+          "rockblast",
+          "fireworks",
+          "flashvolley",
+          "paperseal",
+          "swordsdance",
+          "healorder"
+        ],
+        "lockedMoves": [
+          "micromissiles"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "standocmoon": {
+    "nicknames": [
+      "CMoon"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "contrary"
+        ],
+        "items": [
+          "lifeorb"
+        ],
+        "moves": [
+          "villainpower",
+          "galacticforce",
+          "topsyturvy"
+        ],
+        "lockedMoves": [
+          "superpower"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "standocrazydiamond": {
+    "nicknames": [
+      "Crazy Diamond"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "healer"
+        ],
+        "items": [
+          "lifeorb"
+        ],
+        "moves": [
+          "wish",
+          "healingwish"
+        ],
+        "lockedMoves": [
+          "couragerush",
+          "closecombat"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "standoenigma": {
     "nicknames": [
       "Enigma"
@@ -2211,31 +2737,7 @@
       }
     ]
   },
-  "standostraycat": {
-    "nicknames": [
-      "Stray Cat"
-    ],
-    "sets": [
-      {
-        "abilities": [
-          "magicguard"
-        ],
-        "items": [
-          "lifeorb"
-        ],
-        "moves": [
-          "calmmind",
-          "painsplit",
-          "focusblast"
-        ],
-        "lockedMoves": [
-          "technoray",
-          "shadowball"
-        ],
-        "level": 84
-      }
-    ]
-  },
+  
   "Standokhnum": {
     "nicknames": [
       "Khuumer"
@@ -2260,9 +2762,9 @@
       }
     ]
   },
-  "standoatum": {
+  "standostraycat": {
     "nicknames": [
-      "Stum"
+      "StrayCat"
     ],
     "sets": [
       {
@@ -2281,6 +2783,35 @@
         ],
         "lockedMoves": [
           "airbomb"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "standoatum": {
+    "nicknames": [
+      "Stum"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "magicguard"
+        ],
+        "items": [
+          "angelpowder",
+          "lifeorb"
+        ],
+        "moves": [
+          "energyshield",
+          "painsplit",
+          "shadowball",
+          "flashcannon",
+          "focusblast",
+          "chargebeam",
+          "calmmind"
+        ],
+        "lockedMoves": [
+          "technoray"
         ],
         "level": 84
       }
@@ -2395,43 +2926,7 @@
       }
     ]
   },
-  "yebus": {
-    "nicknames": [
-      "Yebus"
-    ],
-    "sets": [
-      {
-        "abilities": [
-          "drought",
-          "flamebody"
-        ],
-        "items": [
-          "heavydutyboots",
-          "lifeorb",
-          "angelpowder"
-        ],
-        "moves": [
-          "doom",
-          "flamecharge",
-          "earthquake",
-          "insanitybolt",
-          "thunderbolt",
-          "waterfall",
-          "ironhead",
-          "icebeam",
-          "gunkshot",
-          "knockoff",
-          "energyball",
-          "ritual",
-          "invocation"
-        ],
-        "lockedMoves": [
-          "flareblitz"
-        ],
-        "level": 84
-      }
-    ]
-  },
+  
   "standobluenight": {
     "nicknames": [
       "BlueNight"
@@ -2476,7 +2971,7 @@
         ],
         "moves": [
           "jumpkick",
-          "lquidation",
+          "liquidation",
           "sauna"
         ],
         "lockedMoves": [
@@ -3352,30 +3847,7 @@
       }
     ]
   },
-  "wacktentaquil": {
-    "nicknames": [
-      "WackTentaquil"
-    ],
-    "sets": [
-      {
-        "abilities": [
-          "drizzle"
-        ],
-        "items": [
-          "mysticwater"
-        ],
-        "moves": [
-          "hypervoice",
-          "bubblebeam",
-          "hypnosis"
-        ],
-        "lockedMoves": [
-          "downpour"
-        ],
-        "level": 84
-      }
-    ]
-  },
+  
   "demonig": {
     "nicknames": [
       "Demonig"
@@ -3917,6 +4389,34 @@
         }
       ]
     },
+    "plux": {
+      "nicknames": [
+        "Plux"
+      ],
+      "sets": [
+        {
+          "abilities": [
+            "moldbreaker"
+          ],
+          "items": [
+            "angelpowder",
+            "heavydutyboots",
+            "riotshield",
+            "assaultvest"
+          ],
+          "moves": [
+            "angelrush",
+            "closecombat",
+            "earthquake",
+            "ribcage"
+          ],
+          "lockedMoves": [
+            "crosscutter"
+          ],
+          "level": 84
+        }
+      ]
+    },
   "rotting": {
     "nicknames": [
       "Rotting"
@@ -4186,6 +4686,33 @@
       }
     ]
   },
+  
+  "raichu": {   
+    "sets": [
+      {
+        "abilities": [   
+          "static"
+        ],
+        "items": [
+          "magnet",
+          "lifeorb",
+          "angelpowder" 
+        ],
+        "moves": [     
+          "encore",    
+          "aimforthehorn",
+          "maxvoltcrash",
+          "fakeout",
+          "toxic",
+          "uturn",
+          "knockoff",
+          "surf",
+          "protect"
+        ],
+        "level": 84       
+      }
+    ]
+  },
   "warwolf": {
     "nicknames": [
       "Warwolf"
@@ -4230,7 +4757,7 @@
         "lockedMoves": [
           "senshibankou"
         ],
-        "level": 84
+        "level": 72
       }
     ]
   },
@@ -4551,35 +5078,60 @@
       }
     ]
   },
-  "betalapras": {
+  "marsortured": {
     "nicknames": [
-      "Beta Lapras"
+      "Marsortured"
     ],
     "sets": [
       {
         "abilities": [
-          "waterabsorb",
-          "drizzle"
+          "technician"
         ],
         "items": [
-          "lifeorb",
-          "angelpowder",
-          "heavydutyboots"
+          "heavydutyboots",
+          "rockyhelmet"
         ],
         "moves": [
-          "cooldown",
-          "mysticdance",
-          "thunderbolt",
-          "soulchill",
-          "sonar"
+          "guro",
+          "rustedsword",
+          "spite",
+          "marssword"
         ],
         "lockedMoves": [
-          "freezingwave"
+          "torturedspike"
         ],
-        "level": 84
+        "level": 88
       }
     ]
   },
+  "hsalamence": {
+    "nicknames": [
+      "H"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "technician"
+        ],
+        "items": [
+          "heavydutyboots",
+          "rockyhelmet"
+        ],
+        "moves": [
+          "bloodbath",
+          "schizoboost",
+          "heatcrash",
+          "hydropump",
+          "wyverncry"
+        ],
+        "lockedMoves": [
+          "gash"
+        ],
+        "level": 88
+      }
+    ]
+  },
+
   "standoearthwindandfire": {
     "nicknames": [
       "Stando-EarthWindandFire"
@@ -4698,6 +5250,35 @@
       }
     ]
   },
+  "sandslash": {   
+    "sets": [
+      {
+        "abilities": [   
+          "sandveil",
+          "sandrush",
+          "sandforce"
+        ],
+        "items": [
+          "angelpowder",
+          "sitrusberry",
+          "mercuryorb"
+        ],
+        "moves": [     
+          "sandstorm",    
+          "sandslash",
+          "cannonball",
+          "shoreup",
+          "spikes",
+          "stoneedge",
+          "knockoff"
+        ],
+        "lockedMoves": [
+          "rapidspin"
+        ],
+        "level": 84       
+      }
+    ]
+  },
   "brickor": {
     "nicknames": [
       "Brickor"
@@ -4746,6 +5327,34 @@
       }
     ]
   },
+  "vileplume": {   
+    "sets": [
+      {
+        "abilities": [   
+          "effectspore",
+          "chlorophyll"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [     
+          "aromatherapy",    
+          "gigadrain",
+          "toxic",
+          "sleeppowder",
+          "spicypowder",
+          "foulodor",
+          "pollenseason",
+          "sludgebomb",
+          "strengthsap",
+          "earthpower",
+          "compost",
+          "smellycloud"
+        ],   
+        "level": 84       
+      }
+    ]
+  },
   "voormisan": {
     "nicknames": [
       "Voormisan"
@@ -4771,28 +5380,123 @@
       }
     ]
   },
-  "carmillapire": {
+  "wacktentaquil": {
     "nicknames": [
-      "Carmillapire"
+      "WackTentaquil"
     ],
     "sets": [
       {
         "abilities": [
-          "siphon"
+          "drizzle"
         ],
         "items": [
+          "mysticwater"
+        ],
+        "moves": [
+          "hypervoice",
+          "bubblebeam",
+          "hypnosis"
+        ],
+        "lockedMoves": [
+          "downpour"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "whitehand": {
+    "nicknames": [
+      "White Hand"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "souleater"
+        ],
+        "items": [
+          "lifeorb",
+          "heavydutyboots",
           "angelpowder"
         ],
         "moves": [
-          "bloodsiphon",
-          "gigadrain",
-          "vampirebite"
+          "brutal",
+          "painsplit",
+          "ghastlyhand",
+          "shadowclaw"
         ],
         "lockedMoves": [
-          "bloodbite"
+          "fist"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "wigglytuff": {   
+    "sets": [
+      {
+        "abilities": [   
+          "frisk",
+          "cutecharm"
+        ],
+        "items": [
+          "angelpowder",
+          "venusorb",
+          "instantnoodles"
+        ],
+        "moves": [     
+          "mysticdance",    
+          "sonar",
+          "drainingkiss",
+          "puffup",
+          "wish",
+          "stealthrock",
+          "healbell",
+          "gravity",
+          "boomburst",
+          "protect"
+        ],
+        "lockedMoves": [
+          "sing"
+        ],
+        "level": 84       
+      }
+    ]
+  },
+  "yebus": {
+    "nicknames": [
+      "Yebus"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "drought"
+        ],
+        "items": [
+          "heavydutyboots",
+          "lifeorb",
+          "angelpowder"
+        ],
+        "moves": [
+          "doom",
+          "flamecharge",
+          "earthquake",
+          "insanitybolt",
+          "thunderbolt",
+          "waterfall",
+          "ironhead",
+          "icebeam",
+          "gunkshot",
+          "knockoff",
+          "energyball",
+          "ritual",
+          "invocation"
+        ],
+        "lockedMoves": [
+          "flareblitz"
         ],
         "level": 84
       }
     ]
   }
+  
 }

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -42372,7 +42372,21 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 1,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile(move.id)) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
+		secondary: {
+			chance: 20,
+			volatileStatus: 'flinch',
+		},
 		critRatio: 2,
 		target: "normal",
 		type: "Light",
@@ -42461,7 +42475,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 20,
+			volatileStatus: 'flinch',
+		},
 		target: "normal",
 		type: "Heart",
 		isNonstandard: "Future",
@@ -43126,6 +43143,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: -6,
 		flags: {protect: 1, mirror: 1},
+		forceSwitch: true,
 		secondary: null,
 		target: "normal",
 		type: "Cosmic",
@@ -47061,7 +47079,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 20,
+			status: 'tox',
+		},
 		critRatio: 2,
 		target: "normal",
 		type: "Steel",
@@ -47917,8 +47938,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
 		secondary: null,
-		self: {
-			volatileStatus: 'mustrecharge',
+		onAfterHit(target, source) {
+			if (target && target.hp) {
+				source.addVolatile('mustrecharge');
+			}
 		},
 		critRatio: 2,
 		target: "allAdjacentFoes",
@@ -50347,6 +50370,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 1,
 		flags: {protect: 1, mirror: 1},
+		self: {
+			volatileStatus: 'mustrecharge',
+		},
 		secondary: null,
 		target: "normal",
 		type: "Fighting",
@@ -53725,6 +53751,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
+		self: {
+			onHit(source) {
+				this.field.setWeather('midnight');
+			},
+		},
 		target: "normal",
 		type: "Dark",
 		isNonstandard: "Future",
@@ -55758,6 +55789,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
+		onAfterHit(target, source) {
+			if (target && target.hp) {
+				source.addVolatile('mustrecharge');
+			}
+		},
 		secondary: null,
 		critRatio: 2,
 		target: "normal",
@@ -60914,7 +60950,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, bone: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			volatileStatus: 'confusion',
+		},
 		target: "normal",
 		type: "Bone",
 		isNonstandard: "Future",
@@ -60928,7 +60967,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, bone: 1, coral: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			boosts: {
+				def: -1,
+			},
+		},
 		critRatio: 2,
 		target: "normal",
 		type: "Bone",
@@ -67685,7 +67729,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				}
 			},
 			onAfterMove(pokemon, Wood, move) {
-				if (move.type === 'Electric' && move.id !== 'barkskin') {
+				if (move.type === 'Wood' && move.id !== 'barkskin') {
 					pokemon.removeVolatile('barkskin');
 				}
 			},
@@ -68648,8 +68692,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
-		self: {
-			volatileStatus: 'mustrecharge',
+		onAfterHit(target, source) {
+			if (target && target.hp) {
+				source.addVolatile('mustrecharge');
+			}
 		},
 		secondary: null,
 		target: "normal",
@@ -80385,7 +80431,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		overrideDefensiveStat: 'spd',
+		secondary: {
+			chance: 30,
+			volatileStatus: 'curse',
+		},
 		target: "normal",
 		type: "Shadow",
 		isNonstandard: "Future",
@@ -81143,6 +81193,36 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {pulse: 1},
+		pseudoWeather: 'coralreef',
+		condition: {
+			duration: 5,
+			durationCallback(target, source, effect) {
+				if (source?.hasItem('damprock')) {
+					return 10;
+				}
+				return 5;
+			},
+			onFieldStart(field, source) {
+				this.add('-fieldstart', 'move: Coral Reef', '[of] ' + source);
+			},
+			
+			onResidualOrder: 5,
+			onResidualSubOrder: 2,
+			onResidual(pokemon) {
+				if (pokemon.hasType('Water')) {
+					this.heal(pokemon.baseMaxhp / 16);
+				}  
+					else if (!pokemon.hasType('Rock')|| pokemon.hasType('Water')) { 
+					this.damage(pokemon.baseMaxhp / 16);
+				}
+			},
+			
+			onFieldResidualOrder: 27,
+			onFieldResidualSubOrder: 4,
+			onFieldEnd() {
+				this.add('-fieldend', 'move: Coral Reef');
+			},
+		},
 		secondary: null,
 		target: "scripted",
 		type: "Water",
@@ -81157,6 +81237,22 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {snatch: 1, bite: 1},
+		onHit(target, source) {
+			let success = false;
+			if (this.field.getPseudoWeather('coralreef')) {
+				success = !!this.heal(this.modify(target.baseMaxhp, 0.667));
+			} else {
+				success = !!this.heal(Math.ceil(target.baseMaxhp * 0.333));
+			}
+			if (success && !target.isAlly(source)) {
+				target.staleness = 'external';
+			}
+			if (!success) {
+				this.add('-fail', target, 'heal');
+				return this.NOT_FAIL;
+			}
+			return success;
+		},
 		secondary: null,
 		target: "self",
 		type: "Water",
@@ -81171,6 +81267,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, coral: 1},
+		basePowerCallback(source, target, move) {
+			if (this.field.getPseudoWeather('coralreef')) {
+				if (!source.isAlly(target)) this.hint(`${move.name}'s BP doubled on grounded target.`);
+				return move.basePower * 1.5;
+			}
+			return move.basePower;
+		},
+		multihit: [2, 5],
 		secondary: null,
 		critRatio: 2,
 		target: "normal",
@@ -81186,6 +81290,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
+		basePowerCallback(source, target, move) {
+			if (this.field.getPseudoWeather('coralreef')) {
+				return move.basePower * 1.5;
+			}
+			return move.basePower;
+		},
 		secondary: null,
 		critRatio: 2,
 		target: "normal",
@@ -84959,7 +85069,17 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		basePowerCallback(source, target, move) {
+			if (this.field.getPseudoWeather('coralreef')) {
+				return move.basePower * 1.5;
+			}
+			return move.basePower;
+		},
+		secondary: {
+			chance: 60,
+			volatileStatus: 'flinch',
+		},
+		recoil: [33, 100],
 		target: "normal",
 		type: "Water",
 		isNonstandard: "Future",
@@ -86373,8 +86493,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		self: {
-			volatileStatus: 'mustrecharge',
+		onAfterHit(target, source) {
+			if (target && target.hp) {
+				source.addVolatile('mustrecharge');
+			}
 		},
 		secondary: null,
 		target: "allAdjacentFoes",
@@ -87526,8 +87648,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
 		secondary: null,
-		self: {
-			volatileStatus: 'mustrecharge',
+		onAfterHit(target, source) {
+			if (target && target.hp) {
+				source.addVolatile('mustrecharge');
+			}
 		},
 		critRatio: 2,
 		target: "allAdjacentFoes",
@@ -87713,7 +87837,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 45,
+			boosts: {
+				def: -1,
+			},
+		},
 		target: "normal",
 		type: "Bone",
 		isNonstandard: "Future",
@@ -87753,7 +87882,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'slp',
+		},
 		target: "normal",
 		type: "Bone",
 		isNonstandard: "Future",
@@ -87805,7 +87937,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'tox',
+		},
 		target: "normal",
 		type: "Bone",
 		isNonstandard: "Future",


### PR DESCRIPTION
New Randbat Mons: Stando-StrayCat, standobadcompany, standocrazyiamond, standocmoo, hyonix, conix, huonix, onix, exegutor, vieplume, wigglytuff, sandslash, Riachu, marsortured, hsalamence, bloodoom, jcursola, corsola, Reeficoral, Rogyst, Bewdragon, skulloton, plux


New Moves: Vacuumstrike, Vacuum Rupture, all Coral Moves, all Bone type moves, Scarlet Mist, TauroSkiaThermokrasia, rusty blade, courage rush, shimmer strike, fixes most giga impact clones (moves that do not require recharge if you ko oppo)

Adds FFA Randbats and PYT Randbats