### PR TITLE
legalizes 4 mons i forgot in last patch

### DIFF
--- a/data/mods/clovercap/formats-data.ts
+++ b/data/mods/clovercap/formats-data.ts
@@ -1333,6 +1333,36 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		isNonstandard: null,
 		tier: "OU",
 	},
+	klasicope: {
+		inherit: true,
+		isNonstandard: null,
+		tier: "LC",
+	},
+	essention: {
+		inherit: true,
+		isNonstandard: null,
+		tier: "NFE",
+	},
+	termagnius: {
+		inherit: true,
+		isNonstandard: null,
+		tier: "OU",
+	},
+	jumblegore: {
+		inherit: true,
+		isNonstandard: null,
+		tier: "OU",
+	},
+	jumblinart: {
+		inherit: true,
+		isNonstandard: null,
+		tier: "OU",
+	},
+	parmiausan: {
+		inherit: true,
+		isNonstandard: null,
+		tier: "OU",
+	},
 	seaman: {
 		inherit: true,
 		isNonstandard: null,


### PR DESCRIPTION
## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities