### PR TITLE
Correction of the description of the Ra servant sill

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -15049,7 +15049,7 @@ malediction: {
 		onSwitchIn(pokemon) {
 			this.actions.useMove(Dex.moves.get('Max Flare'), pokemon);
 		},
-		name: "Rá Servant ",
+		name: "Ra Servant ",
 		rating: 3,
 		num: 422,
 		isNonstandard: "Future",
@@ -15148,6 +15148,17 @@ malediction: {
 			this.actions.useMove(Dex.moves.get('Minimize'), pokemon);
 		},
 		name: "the little one",
+		rating: 3,
+		num: 422,
+		isNonstandard: "Future",
+	},
+
+	flashlight: {
+		onSwitchInPriority: 4,
+		onSwitchIn(pokemon) {
+			this.actions.useMove(Dex.moves.get('Flashbang'), pokemon);
+		},
+		name: "Flash Light",
 		rating: 3,
 		num: 422,
 		isNonstandard: "Future",

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -4062,6 +4062,10 @@ malediction: {
 		name: "The Little One",
 		shortDesc: "Summons Minimize",
 	},
+	flashlight: {
+		name: "Flash Light",
+		shortDesc: "Summons Flashbang",
+	},
 
 
 	


### PR DESCRIPTION
Correction of the description of the Ra servant skill and add +1

## Description
correction by removing accentuation, and adding new

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities