### PR TITLE
bandicute thicc bone + cap lc bans

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -1171,7 +1171,7 @@ export const Formats: FormatList = [
 			'Dynamax Clause',
 			'Sketch Post-Gen 7 Moves',
 		],
-		banlist: ['Moody', 'Baton Pass', 'Dragon Rage', 'Sonic Boom', 'Ribbizap', 'Cursed Fang', 'Crimson Lens', 'Dinomight'],
+		banlist: ['Moody', 'Baton Pass', 'Dragon Rage', 'Sonic Boom', 'Ribbizap', 'Cursed Fang', 'Crimson Lens', 'Dinomight', 'Sphare', 'Yuukiino', 'Honrade'],
 	},
 	{
 		name: '[Gen 8 Clover CAP Only] Monotype',

--- a/data/mods/clovercap/formats-data.ts
+++ b/data/mods/clovercap/formats-data.ts
@@ -1266,7 +1266,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	sphare: {
 		inherit: true,
 		isNonstandard: null,
-		tier: "LC",
+		tier: "NFE",
 	},
 	costrike: {
 		inherit: true,

--- a/data/mods/clovercap/items.ts
+++ b/data/mods/clovercap/items.ts
@@ -188,11 +188,11 @@ export const Items: {[k: string]: ModdedItemData} = {
 		inherit: true,
 		onModifyAtkPriority: 1,
 		onModifyAtk(atk, pokemon) {
-			if (pokemon.baseSpecies.baseSpecies === 'Naughtycoot' || pokemon.baseSpecies.baseSpecies === 'Masdawg' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Gambino' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Toadagi' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Whiteout' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Swoldier' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Mr. Toad' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Staypuft' || pokemon.baseSpecies.baseSpecies === 'Pasdawg') {
+			if (pokemon.baseSpecies.baseSpecies === 'Bandicute' || pokemon.baseSpecies.baseSpecies === 'Naughtycoot' || pokemon.baseSpecies.baseSpecies === 'Masdawg' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Gambino' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Toadagi' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Whiteout' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Swoldier' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Mr. Toad' || pokemon.baseSpecies.baseSpecies === 'Pasdawg-Staypuft' || pokemon.baseSpecies.baseSpecies === 'Pasdawg') {
 				return this.chainModify(2);
 			}
 		},
-		itemUser: ["Masdawg", "Pasdawg", "Naughtycoot", "Blobbos-Skeleton", "Pasdawg-Gambino", "Pasdawg-Toadagi", "Pasdawg-Whiteout", "Pasdawg-Swoldier", "Pasdawg-Mr. Toad", "Pasdawg-Staypuft"],
+		itemUser: ["Masdawg", "Pasdawg", "Bandicute", "Naughtycoot", "Blobbos-Skeleton", "Pasdawg-Gambino", "Pasdawg-Toadagi", "Pasdawg-Whiteout", "Pasdawg-Swoldier", "Pasdawg-Mr. Toad", "Pasdawg-Staypuft"],
 		isNonstandard: null,
 	},
 	/* Clover CAP Exclusive Items */

--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -34716,7 +34716,7 @@ export const Pokedex: {[speciesid: string]: SpeciesData} = {
 		name: "Bandicute",
 		types: ["Ground"],
 		genderRatio: {M: 0.5, F: 0.5},
-		baseStats: {hp: 70, atk: 70, def: 65, spa: 39, spd: 46, spe: 50},
+		baseStats: {hp: 70, atk: 64, def: 65, spa: 39, spd: 46, spe: 50},
 		abilities: {0: "Own Tempo", 1: "Prankster", H: "Sand Veil", S: "Oblivious"},
 		heightm: 0.4,
 		weightkg: 7.2,


### PR DESCRIPTION
lets bandicute use the thicc bone, makes it lose 6 atk
bans yuukiino, sphare, and honrade from cap lc