### PR TITLE
Patch 26

### DIFF
--- a/data/mods/wack/formats-data.ts
+++ b/data/mods/wack/formats-data.ts
@@ -29387,22 +29387,22 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	corsolagalar: {
   		inherit: true,
-  		tier: "UU",
+  		tier: "Illegal",
   		isNonstandard: null,
 	},
 	slowkinggalar: {
   		inherit: true,
-  		tier: "UU",
+  		tier: "Illegal",
   		isNonstandard: null,
 	},
 	zapdosgalar: {
   		inherit: true,
-  		tier: "UU",
+  		tier: "Illegal",
   		isNonstandard: null,
 	},
 	moltresgalar: {
   		inherit: true,
-  		tier: "UU",
+  		tier: "Illegal",
   		isNonstandard: null,
 	},
 };

--- a/data/mods/wack/formats-data.ts
+++ b/data/mods/wack/formats-data.ts
@@ -29375,4 +29375,34 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 		tier: "Uber",
 		isNonstandard: null,
 	},
+	landorustherian: {
+  		inherit: true,
+  		tier: "UU",
+  		isNonstandard: null,
+	},
+	tornadustherian: {
+  		inherit: true,
+  		tier: "UU",
+  		isNonstandard: null,
+	},
+	corsolagalar: {
+  		inherit: true,
+  		tier: "UU",
+  		isNonstandard: null,
+	},
+	slowkinggalar: {
+  		inherit: true,
+  		tier: "UU",
+  		isNonstandard: null,
+	},
+	zapdosgalar: {
+  		inherit: true,
+  		tier: "UU",
+  		isNonstandard: null,
+	},
+	moltresgalar: {
+  		inherit: true,
+  		tier: "UU",
+  		isNonstandard: null,
+	},
 };


### PR DESCRIPTION
## Description
fixed some mons that shouldn't be in wack

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities