### PR TITLE
Updated "Hyper Beam" moves in Wack

### DIFF
--- a/data/mods/wack/moves.ts
+++ b/data/mods/wack/moves.ts
@@ -1235,6 +1235,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	eternabeam: {
 		inherit: true,
 		pp: 5,
+		self: null,
+		onHit(target, source) {
+			if (!target.hp) {
+				source.addVolatile('mustrecharge');
+			}
+		},
+		desc: "Unless the target faints, the user must rest on the next turn.",
+		shortDesc: "Unless the target faints, the user must rest on the next turn.",
 		isNonstandard: null,
 	},
 	extrasensory: {
@@ -1892,6 +1900,14 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		inherit: true,
 		accuracy: 90,
 		flags: {contact: 1, protect: 1, recharge: 1, mirror: 1},
+		onAfterHit() {},
+		onHit(target, source) {
+			if (!target.hp) {
+				source.addVolatile('mustrecharge');
+			}
+		},
+		desc: "Unless the target faints, the user must rest on the next turn.",
+		shortDesc: "Unless the target faints, the user must rest on the next turn.",
 	},
 	meteormash: {
 		inherit: true,
@@ -4418,22 +4434,25 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	},
 	gigaimpact: {
 		inherit: true,
-			accuracy: 90,
-			basePower: 150,
-			category: "Physical",
-			name: "Giga Impact",
-			pp: 5,
-			priority: 0,
-			flags: {contact: 1, recharge: 1, protect: 1, mirror: 1},
-			onAfterHit(target, source) {
-				if (target && target.hp) {
-					source.addVolatile('mustrecharge');
-				}
-			},
-			secondary: null,
-			target: "normal",
-			type: "Normal",
-			contestType: "Tough",
+		accuracy: 90,
+		basePower: 150,
+		category: "Physical",
+		name: "Giga Impact",
+		pp: 5,
+		priority: 0,
+		flags: {contact: 1, recharge: 1, protect: 1, mirror: 1},
+		self: null,
+		onHit(target, source) {
+			if (!target.hp) {
+				source.addVolatile('mustrecharge');
+			}
+		},
+		secondary: null,
+		target: "normal",
+		type: "Normal",
+		contestType: "Tough",
+		desc: "If this move is successful, the user must recharge on the following turn and cannot make a move. If the target is knocked out by this move, the user does not have to recharge.",
+		shortDesc: "User cannot move next turn, if the target isn't KO'ed.",
 		isNonstandard: null,
 	},
 	gigatonhammer: {
@@ -4559,21 +4578,24 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 	hyperbeam: {
 		inherit: true,
 		accuracy: 90,
-			basePower: 150,
-			category: "Physical",
-			name: "Giga Impact",
-			pp: 5,
-			priority: 0,
-			flags: {contact: 1, recharge: 1, protect: 1, mirror: 1},
-			onAfterHit(target, source) {
-				if (target && target.hp) {
-					source.addVolatile('mustrecharge');
-				}
-			},
-			secondary: null,
-			target: "normal",
-			type: "Normal",
-			contestType: "Tough",
+		basePower: 150,
+		category: "Special",
+		name: "Hyper Beam",
+		pp: 5,
+		priority: 0,
+		flags: {contact: 1, recharge: 1, protect: 1, mirror: 1},
+		self: null,
+		onHit(target, source) {
+			if (!target.hp) {
+				source.addVolatile('mustrecharge');
+			}
+		},
+		secondary: null,
+		target: "normal",
+		type: "Normal",
+		contestType: "Tough",
+		desc: "If this move is successful, the user must recharge on the following turn and cannot make a move. If the target is knocked out by this move, the user does not have to recharge.",
+		shortDesc: "User cannot move next turn, if the target isn't KO'ed.",
 		isNonstandard: null,
 	},
 	hyperdrill: {

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -48248,8 +48248,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
 		secondary: null,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -55127,8 +55127,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -56014,8 +56014,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -56200,8 +56200,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Burst Stream",
 		pp: 5,
 		priority: 0,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -56259,8 +56259,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -62587,8 +62587,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "STONER SUNSHINE",
 		pp: 5,
 		priority: 0,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -62969,8 +62969,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		secondary: null,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -67349,8 +67349,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Flavor Town",
 		pp: 5,
 		priority: 0,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -69429,8 +69429,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -73939,8 +73939,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -87460,8 +87460,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -87941,9 +87941,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},
@@ -88642,8 +88641,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
 		secondary: null,
-		onAfterHit(target, source) {
-			if (target && target.hp) {
+		onHit(target, source) {
+			if (!target.hp) {
 				source.addVolatile('mustrecharge');
 			}
 		},


### PR DESCRIPTION
## Description
Fixing "Hyper Beam" moves and clones in Wack. They work like in older gens where, if it KOs, the pokemon doesn't need to recharge. (Not every clone have this property tho)

Can't wait til I'm asked to ban them.

## Checklist
- [x] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [x] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [x] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities