### PR TITLE
0 Atk Blobbos-Gigantamax G-Max Blob Bomb vs. 252 HP / 252+ Def Blobbos-King: 351-413 (94.3 - 111%) -- 68.8% chance to OHKO

### DIFF
--- a/data/moves.ts
+++ b/data/moves.ts
@@ -28778,8 +28778,8 @@ export const Moves: {[moveid: string]: MoveData} = {
 	},
 	gmaxblobbomb: {
 		num: 69028,
-		accuracy: 100,
-		basePower: 160,
+		accuracy: true,
+		basePower: 10,
 		category: "Physical",
 		name: "G-Max Blob Bomb",
 		pp: 5,


### PR DESCRIPTION
## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities