### PR TITLE
[CAP] Dispenser Rework

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -7437,15 +7437,14 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 					this.add('-ability', pokemon, 'Dispenser');
 					activated = true;
 				}
-				ally.heal(ally.baseMaxhp / 10);
+				ally.heal(ally.baseMaxhp / 16);
 				this.add('-heal', ally, ally.getHealth);
-				const moveSlots = ally.moveSlots.filter(move => move.pp < move.maxpp);
-				if (moveSlots.length) {
-					const moveSlot = this.sample(moveSlots);
-					moveSlot.pp += 1;
-					if (moveSlot.pp > moveSlot.maxpp) moveSlot.pp = moveSlot.maxpp;
-					this.add('-activate', ally, 'ability: Dispenser', moveSlot.move, '[of] ' + pokemon);
-				}
+			}
+			if (pokemon.hp && !pokemon.item) {
+				if (pokemon.item || !pokemon.lastItem && !this.dex.items.get(pokemon.lastItem).isBerry) return false;
+				pokemon.setItem(pokemon.lastItem);
+				pokemon.lastItem = '';
+				this.add('-item', pokemon, pokemon.getItem(), '[from] ability: Dispenser');
 			}
 		},
 		name: "Dispenser",
@@ -7466,7 +7465,7 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				this.add('-heal', ally, ally.getHealth);
 			}
 			if (pokemon.hp && !pokemon.item) {
-				if (pokemon.item || !pokemon.lastItem) return false;
+				if (pokemon.item || !pokemon.lastItem && !this.dex.items.get(pokemon.lastItem).isBerry) return false;
 				pokemon.setItem(pokemon.lastItem);
 				pokemon.lastItem = '';
 				this.add('-item', pokemon, pokemon.getItem(), '[from] ability: Fake-Ass Dispenser Clone');

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -7451,30 +7451,6 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		rating: 4,
 		isNonstandard: "Future",
 	},
-	fakeassdispenserclone: {
-		onResidualOrder: 26,
-		onResidualSubOrder: 1,
-		onResidual(pokemon, source, effect) {
-			let activated = false;
-			for (const ally of pokemon.alliesAndSelf()) {
-				if (!activated) {
-					this.add('-ability', pokemon, 'Fake-Ass Dispenser Clone');
-					activated = true;
-				}
-				ally.heal(ally.baseMaxhp / 16);
-				this.add('-heal', ally, ally.getHealth);
-			}
-			if (pokemon.hp && !pokemon.item) {
-				if (pokemon.item || !pokemon.lastItem && !this.dex.items.get(pokemon.lastItem).isBerry) return false;
-				pokemon.setItem(pokemon.lastItem);
-				pokemon.lastItem = '';
-				this.add('-item', pokemon, pokemon.getItem(), '[from] ability: Fake-Ass Dispenser Clone');
-			}
-		},
-		name: "Fake-Ass Dispenser Clone",
-		rating: 4,
-		isNonstandard: "Future",
-	},
 	leech: {
 		onModifyMove(move) {
 			if (!move?.flags['contact'] || move.target === 'self') return;

--- a/data/aliases.ts
+++ b/data/aliases.ts
@@ -565,7 +565,6 @@ export const Aliases: {[alias: string]: string} = {
 	stag: "Shadow Tag",
 	stride: "AIN'T NOTHIN' GONNA BREAK MY STRIDE",
 	angbms: "AIN'T NOTHIN' GONNA BREAK MY STRIDE",
-	fadc: "Fake-Ass Dispenser Clone",
 
 	// items
 	assvest: "Assault Vest",

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -2548,7 +2548,7 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	dispenser: {
 		name: "Dispenser",
 		
-		shortDesc: "At the end of every turn, heals user and allies for 1/16 of their max HP and recycles the user's item.",
+		shortDesc: "At the end of every turn, heals user and allies for 1/16 of their max HP and recycles the user's item, unless it's a berry.",
 		addItem: "  [POKEMON] dispensed one [ITEM]!",
 	},
 	fakeassdispenserclone: {

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -2547,8 +2547,9 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 	},
 	dispenser: {
 		name: "Dispenser",
-		shortDesc: "At the end of every turn, heals user and allies for 1/10 of their max HP and 1 PP to one of their moves.",
-		activate: "  [SOURCE]'s Dispenser restored the PP of [TARGET]'s [MOVE] by 1!",
+		
+		shortDesc: "At the end of every turn, heals user and allies for 1/16 of their max HP and recycles the user's item.",
+		addItem: "  [POKEMON] dispensed one [ITEM]!",
 	},
 	fakeassdispenserclone: {
 		name: "Fake-Ass Dispenser Clone",

--- a/data/text/abilities.ts
+++ b/data/text/abilities.ts
@@ -2551,11 +2551,6 @@ export const AbilitiesText: {[k: string]: AbilityText} = {
 		shortDesc: "At the end of every turn, heals user and allies for 1/16 of their max HP and recycles the user's item, unless it's a berry.",
 		addItem: "  [POKEMON] dispensed one [ITEM]!",
 	},
-	fakeassdispenserclone: {
-		name: "Fake-Ass Dispenser Clone",
-		shortDesc: "At the end of every turn, heals user and allies for 1/16 of their max HP and recycles the user's item.",
-		addItem: "  [POKEMON] dispensed another [ITEM]!",
-	},
 	eclipse: {
 		name: "Eclipse",
 		desc: "On switch-in, removes Sunny Day and Desolate Land for a stat boost.",


### PR DESCRIPTION
Reworks Dispenser to restore 1/16th HP and to recycle the user's non-Berry item on turn end.
Kills Fake-Ass Dispenser Clone because it's no longer necessary.