### PR TITLE
Wack Stuff

### DIFF
--- a/data/mods/wack/random-sets.json
+++ b/data/mods/wack/random-sets.json
@@ -676,6 +676,30 @@
       }
     ]
   },
+  "elsnow": {
+    "nicknames": [
+      "Let It Go"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "snowwarning"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [
+          "venusburst",
+          "coldheart"
+        ],
+        "lockedMoves": [
+          "glacialrend",
+          "subzerowail"
+        ],
+        "level": 82
+      }
+    ]
+  },
   "endragon": {   
     "nicknames": [   
       "steve",    
@@ -732,6 +756,32 @@
           "electroncrush"
         ],
         "level": 84
+      }
+    ]
+  },
+  "fissiom": {
+    "nicknames": [
+      "Fissiom"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "toxicboost"
+        ],
+        "items": [
+          "toxicorb"
+        ],
+        "moves": [
+          "technoray",
+          "thunderbolt",
+          "icebeam"
+        ],
+        "lockedMoves": [
+          "slitwrists",
+          "atombomb",
+          "heatseekmissile"
+        ],
+        "level": 83
       }
     ]
   },
@@ -1507,6 +1557,33 @@
       }
     ]
   },
+  "gigagigerth": {
+    "nicknames": [
+      "Gerth"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "filter"
+        ],
+        "items": [
+          "shatteringhammer",
+          "heavydutyboots"
+        ],
+        "moves": [
+          "stealthrock",
+          "toxic",
+          "earthquake",
+          "elastickick",
+          "highhorsepower"
+        ],
+        "lockedMoves": [
+          "rockblast"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "sudorokku": {   
     "sets": [
       {
@@ -1855,7 +1932,7 @@
           
         ],
         "moves": [
-          "bassknuckle",
+          "brassknuckle",
           "knockoff",
           "gunkshot",
           "grapple"
@@ -1863,6 +1940,560 @@
         "lockedMoves": [
           "curse",
           "doubleedge"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "rlimshaikworm": {
+    "nicknames": [
+      "Rlimshaikworm"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "liquidooze"
+        ],
+        "items": [
+          "heavydutyboots",
+          "lifeorb"
+          
+        ],
+        "moves": [
+          "haze",
+          "bloodseal",
+          "bloodshower",
+          "bloodrain",
+          "wringout"
+        ],
+        "lockedMoves": [
+          "pukeblood",
+          "icebeam"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "eihortli": {
+    "nicknames": [
+      "Eihortli"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "focus"
+        ],
+        "items": [
+          "heavydutyboots",
+          "leftovers"
+          
+        ],
+        "moves": [
+          "invokedread",
+          "leechseed",
+          "insanitybolt"
+        ],
+        "lockedMoves": [
+          "bloodsiphon",
+          "devildeal"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "nukrylic": {
+    "nicknames": [
+      "Nukrylic"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "colorchange"
+        ],
+        "items": [
+          "gallerycapsule",
+          "whiteherb"         
+        ],
+        "moves": [
+          "shellsmash",
+          "sketch"
+        ],
+        "lockedMoves": [
+          "bucketbomb",
+          "atombomb"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "painter": {
+    "nicknames": [
+      "Literally Hitler"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "colorchange"
+        ],
+        "items": [
+          "gallerycapsule",
+          "whiteherb"         
+        ],
+        "moves": [
+          "cubism",
+          "thermochromia"
+        ],
+        "lockedMoves": [
+          "bucketbomb",
+          "atombomb"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "glassbol": {
+    "nicknames": [
+      "Glassbol"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "weakarmor",
+          "clearbody"
+        ],
+        "items": [
+          "lifeorb",
+          "heavydutyboots",
+          "angelpowder"         
+        ],
+        "moves": [
+          "wringout",
+          "glassdefense"
+        ],
+        "lockedMoves": [
+          "glasssparkle",
+          "glasscannon"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "maglamp": {
+    "nicknames": [
+      "Maglamp"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "magmaarmor",
+          "solarpower"
+        ],
+        "items": [
+          "whiteherb",
+          "heavydutyboots",
+          "angelpowder"         
+        ],
+        "moves": [
+          "recover",
+          "beacon",
+          "gasoline",
+          "flameburst"
+        ],
+        "lockedMoves": [
+          "magmastorm",
+          "prismray"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "kasanova": {
+    "nicknames": [
+      "Kasanova"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "shielddust"
+        ],
+        "items": [
+          "heavydutyboots",
+          "angelpowder",
+          "sitrusberry"        
+        ],
+        "moves": [
+          "bellydrum",
+          "stunspore",
+          "bulkup",
+          "rockslide",
+          "uturn",
+          "swordsdance"
+        ],
+        "lockedMoves": [
+          "lunge",
+          "antennatracker"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "atogekiss": {
+    "nicknames": [
+      "A Togekiss"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "shielddust"
+        ],
+        "items": [
+          "heavydutyboots",
+          "angelpowder",
+          "sitrusberry"        
+        ],
+        "moves": [
+          "dragonpulse",
+          "aurasphere",
+          "ancientpower",
+          "wish",
+          "batonpass"
+        ],
+        "lockedMoves": [
+          "airslash",
+          "dragonbreath"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "whitedoor": {
+    "nicknames": [
+      "White Door"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "blaze"
+        ],
+        "items": [
+          "blunderpolicy"  
+        ],
+        "moves": [
+          "heatmirage",
+          "toxic",
+          "mirrorcoat",
+          "counter",
+          "luckychant",
+          "insanity"
+        ],
+        "lockedMoves": [
+          "sunburn",
+          "inferno"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "ahchah": {
+    "nicknames": [
+      "Ahchah"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "protean"
+        ],
+        "items": [
+          "heavydutyboots",
+          "lifeorb",
+          "angelpowder"  
+        ],
+        "moves": [
+          "bucketbomb",
+          "gash",
+          "defog",
+          "zombiespread",
+          "mefirst",
+          "coralreef"
+        ],
+        "lockedMoves": [
+          "kanshoubakuya"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "acrylomodo": {
+    "nicknames": [
+      "Acrylomodo"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "colorchange"
+        ],
+        "items": [
+          "gallerycapsule"          
+        ],
+        "moves": [
+          "dragondance",
+          "dragonruins",
+          "outrage",
+          "dragonclaw"
+        ],
+        "lockedMoves": [
+          "bucketbomb"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "berserkalot": {
+    "nicknames": [
+      "Berserkalot"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "protean"
+        ],
+        "items": [
+          "chaosdust"  
+        ],
+        "moves": [
+          "acrobatics",
+          "mount",
+          "insanity",
+          "honeclaws"
+        ],
+        "lockedMoves": [
+          "dragonslayer",
+          "arondight"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "rideusa": {
+    "nicknames": [
+      "Rideusa"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "protean"
+        ],
+        "items": [
+          "chaosdust",
+          "divinedust"
+        ],
+        "moves": [
+          "acrobatics",
+          "mount",
+          "lightscreen"
+        ],
+        "lockedMoves": [
+          "bellerophon",
+          "bloodandromeda"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "necrolilith": {
+    "nicknames": [
+      "Necrolilith"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "magicbounce"
+        ],
+        "items": [
+          "murkycapsule"
+        ],
+        "moves": [
+          "flamethrower",
+          "healbell",
+          "nastyplot"
+        ],
+        "lockedMoves": [
+          "blackmagic",
+          "corpsewave"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "necroseel": {
+    "nicknames": [
+      "Necroseel"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "strongjaw"
+        ],
+        "items": [
+          "murkycapsule"
+        ],
+        "moves": [
+          "corpsewave",
+          "rottingburst",
+          "eyegouge",
+          "crunch",
+          "shamble",
+          "icefang"
+        ],
+        "lockedMoves": [
+          "zombiebite",
+          "aquacrunch"
+        ],
+        "level": 84
+      }
+    ]
+  },
+ 
+  "nexaphago": {
+    "nicknames": [
+      "Nexaphago"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "protean"
+        ],
+        "items": [
+          "chaosdust",
+          "divinedust"
+        ],
+        "moves": [
+          "mindcontrol",
+          "foulplay",
+          "anaphylacticshock",
+          "nastyplot",
+          "leechseed",
+          "extrachromosome",
+          "virus"
+        ],
+        "lockedMoves": [
+          "ebola"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "austisma": {
+    "nicknames": [
+      "Autisma"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "irradiated"
+        ],
+        "items": [
+          "angelpowder",
+          "heavydutyboots"
+        ],
+        "moves": [
+          "playrough",
+          "healbell",
+          "attract",
+          "extrachromosome",
+          "healpulse",
+          "sweetkiss",
+          "virus"
+        ],
+        "lockedMoves": [
+          "cbt",
+          "numbinginjection"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "nursebola": {
+    "nicknames": [
+      "Nursebola"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "irradiated",
+          "safeshield"
+        ],
+        "items": [
+          "angelpowder",
+          "heavydutyboots"
+        ],
+        "moves": [
+          "bloodpump",
+          "foulnote",
+          "attract",
+          "extrachromosome",
+          "healpulse",
+          "sweetkiss",
+          "virus",
+          "contaminate"
+        ],
+        "lockedMoves": [
+          "ebola",
+          "fever"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "ballough": {
+    "nicknames": [
+      "Ballough"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "cutecharm"
+        ],
+        "items": [
+          "angelpowder",
+          "heavydutyboots"
+        ],
+        "moves": [
+          "selffatten",
+          "anaphylacticshock",
+          "cakewalk"
+        ],
+        "lockedMoves": [
+          "nutrientdrain",
+          "fever"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "splague": {
+    "nicknames": [
+      "Splague"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "infected"
+        ],
+        "items": [
+          "angelpowder",
+          "heavydutyboots"
+        ],
+        "moves": [
+          "anaphylacticshock",
+          "wormhole",
+          "viruspropogate",
+          "contaminate",
+          "memento"
+        ],
+        "lockedMoves": [
+          "infestation",
+          "spacevirus"
         ],
         "level": 84
       }
@@ -1985,6 +2616,33 @@
         "lockedMoves": [
           "shinigamieyes",
           "shadowball"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "bleedtoise": {
+    "nicknames": [
+      "Bleedtoise"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "infected"
+        ],
+        "items": [
+          "murkycapsule",
+          "acidycapsule",
+          "rainycapsule"
+        ],
+        "moves": [
+          "primalnoise"
+        ],
+        "lockedMoves": [
+          "corpsewave",
+          "bloodpump",
+          "hydropump"
+
         ],
         "level": 84
       }
@@ -2736,6 +3394,31 @@
       }
     ]
   },
+  "wymaiden": {
+    "nicknames": [
+      "Wymaiden"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "pickpocket"
+        ],
+        "items": [
+          "dragongem"
+        ],
+        "moves": [
+          "knockoff",
+          "cbt"
+        ],
+        "lockedMoves": [
+          "dragonvenom",
+          "loveburst",
+          "raid"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "meatko": {
     "nicknames": [
       "Meatko"
@@ -2932,6 +3615,50 @@
           "toxicinfo"
         ],
         "level": 84
+      }
+    ]
+  },
+  "mspain": {
+    "nicknames": [
+      "Monster Pain"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "protean"
+        ],
+        "items": [
+          "chaosdust",
+          "divinedust"
+        ],
+        "moves": [
+          "insanitybolt",
+          "inkblast",
+          "woodball",
+          "fireblast",
+          "energyball",
+          "thunderbolt"
+        ],
+        "lockedMoves": [
+          "paintprint",
+          "bloodystorm"
+        ],
+        "level": 83
+      },
+      {
+        "abilities": [
+          "breakdown"
+        ],
+        "items": [
+          "gallerycapsule"    
+        ],
+        "lockedMoves": [
+          "slitwrists",
+          "inkblast",
+          "bloodystorm",
+          "flamethrower"
+        ],
+        "level": 84        
       }
     ]
   },
@@ -3704,7 +4431,7 @@
           "protean"
         ],
         "items": [
-          "angelpower",
+          "angelpowder",
           "heavydutyboots" 
         ],
         "moves": [     
@@ -3727,7 +4454,7 @@
           "protean"
         ],
         "items": [
-          "angelpower",
+          "angelpowder",
           "heavydutyboots" 
         ],
         "moves": [     
@@ -3783,6 +4510,33 @@
       } 
     ]
   }, 
+  "clamppelo": {
+    "nicknames": [
+      "The Clamps"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "strongjaw"
+        ],
+        "items": [
+          "vampirefangs"
+        ],
+        "moves": [
+          "icefang",
+          "thunderfang",
+          "sewing",
+          "wrapped"
+        ],
+        "lockedMoves": [
+          "crunch",
+          "artificiaslam",
+          "carpetburn"
+        ],
+        "level": 84
+      }
+    ]
+  },
 "Clownpairy": {   
     "sets": [
       {
@@ -3790,7 +4544,7 @@
           "colorchange"
         ],
         "items": [
-          "angelpower",
+          "angelpowder",
           "heavydutyboots" 
         ],
         "moves": [     
@@ -3812,7 +4566,7 @@
           "colorchange"
         ],
         "items": [
-          "angelpower",
+          "angelpowder",
           "heavydutyboots" 
         ],
         "moves": [     
@@ -4040,6 +4794,34 @@
         ],
         "lockedMoves": [
           "moonblast"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "bigmallow": {
+    "nicknames": [
+      "Bigmallow"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "safeshield",
+          "thickfat"
+        ],
+        "items": [
+          "angelpowder",
+          "heavydutyboots",
+          "focussash"
+        ],
+        "moves": [
+          "seismictoss",
+          "healingwish",
+          "fattenup"
+        ],
+        "lockedMoves": [
+          "counter",
+          "mirrorcoat"
         ],
         "level": 84
       }
@@ -4273,6 +5055,34 @@
       }
     ]
   },
+ "doomsayw": {
+    "nicknames": [
+      "Doomsay"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "forewarn"
+        ],
+        "items": [
+          "murkycapsule"
+        ],
+        "moves": [
+          "haunt",
+          "madprophecy",
+          "shadow",
+          "graverob",
+          "shamble",
+          "ritual"
+        ],
+        "lockedMoves": [
+          "rottenclaw",
+          "shadowclaw"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "neonazi": {
     "nicknames": [
       "Neonazi"
@@ -4380,6 +5190,35 @@
           "gigaimpact"
         ],
         "level": 84
+      }
+    ]
+  },
+  "baxbak": {
+    "nicknames": [
+      "Baxbak"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "siphon",
+          "graze"
+        ],
+        "items": [
+          "murkycapsule",
+          "lifeorb",
+          "heavydutyboots",
+          "angelpowder"
+        ],
+        "moves": [
+          "arcticcrash",
+          "rotfangs",
+          "hornleach"
+        ],
+        "lockedMoves": [
+          "zombiespread",
+          "cannibalize"
+        ],
+        "level": 88
       }
     ]
   },
@@ -4788,6 +5627,36 @@
       }
     ]
   },
+  "harcanine": {
+    "nicknames": [
+      "Rockanine"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "filter"
+        ],
+        "items": [
+          "choicescarf",
+          "assaultvest",
+          "lifeorb",
+          "heavydutyboots",
+          "angelpowder"
+        ],
+        "moves": [
+          "sacredfire",
+          "playrough",
+          "doubleedge",
+          "wildcharge"
+        ],
+        "lockedMoves": [
+          "stoneedge",
+          "flareblitz"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "herculecross": {
     "nicknames": [
       "Herculecross"
@@ -4807,6 +5676,37 @@
         ],
         "lockedMoves": [
           "pinmissile"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "ionnine": {
+    "nicknames": [
+      "Shitcanine"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "ionate"
+        ],
+        "items": [
+          "lifeorb",
+          "heavydutyboots",
+          "angelpowder"
+        ],
+        "moves": [
+          "morningsun",
+          "toxic",
+          "closecombat",
+          "flareblitz",
+          "gigaimpact",
+          "extremespeed",
+          "doubleedge",
+          "facade"
+        ],
+        "lockedMoves": [
+          "barking"
         ],
         "level": 84
       }
@@ -5025,6 +5925,32 @@
         ],
         "lockedMoves": [
           "aeroblast"
+        ],
+        "level": 78
+      }
+    ]
+  },
+  "sloggeroth": {
+    "nicknames": [
+      "Sloggeroth"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "protean"
+        ],
+        "items": [
+          "divinedust",
+          "chaosdust"
+        ],
+        "moves": [
+          "earthpower",
+          "sludgebomb",
+          "roar"
+        ],
+        "lockedMoves": [
+          "voidsmaw",
+          "patchworkdeluge"
         ],
         "level": 78
       }
@@ -5749,6 +6675,34 @@
       }
     ]
   },
+  "hunballun": {
+    "nicknames": [
+      "Hunballun"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "thickfat",
+          "graze"
+        ],
+        "items": [
+          "leftovers",
+          "saunacapsule"
+        ],
+        "moves": [
+          "steamup",
+          "steamclean",
+          "fart",
+          "delivery"
+        ],
+        "lockedMoves": [
+          "selffatten",
+          "steamblast"
+        ],
+        "level": 80
+      }
+    ]
+  },
   "huweedle": {
     "nicknames": [
       "Huweedle"
@@ -6255,6 +7209,31 @@
       } 
     ]
   },
+  "paintip": {
+    "nicknames": [
+      "Just the Tip"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "prankster"
+        ],
+        "items": [
+          "angelpowder"
+        ],
+        "moves": [
+          "corpsewave",
+          "jyuouhanketsu",
+          "aquariusflow"
+        ],
+        "lockedMoves": [
+          "bucketbomb",
+          "thermochromia"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "pmrmime": {
     "nicknames": [
       "Paint Mr. Mime"
@@ -6677,6 +7656,56 @@
       }
     ]
   },
+  "mecharbok": {
+    
+    "sets": [
+      {
+        "abilities": [
+          "intimidate"
+        ],
+        "items": [
+          "acidycapsule"
+        ],
+        "moves": [
+          "antivenom",
+          "hallucinogen",
+          "switcheroo"
+        ],
+        "lockedMoves": [
+          "dragontail",
+          "malfunction"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "mechaking": {
+    
+    "sets": [
+      {
+        "abilities": [
+          "levitate",
+          "sheerforce"
+        ],
+        "items": [
+          "lifeorb",
+          "acidycapsule"
+        ],
+        "moves": [
+          "kingsshield",
+          "numbinginjection",
+          "acidbath",
+          "earthpower",
+          "primalnoise"
+        ],
+        "lockedMoves": [
+          "poisonjab",
+          "irontail"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "metaletemon": {
     
     "sets": [
@@ -6854,7 +7883,7 @@
   },
   "mukma": {
     "nicknames": [
-      "Mukma"
+      "Mukafuka"
     ],
     "sets": [
       {
@@ -6939,17 +7968,42 @@
           "intimidate"
         ],
         "items": [
-          "powerherb"
+          "whiteherb"
         ],
         "moves": [
-          "schizoboost",
           "throatchop",
           "voidsmaw",
           "insanitybolt"
         ],
         "lockedMoves": [
+          "schizoboost",
           "thenword",
           "eldritchgoop"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "yanenvy": {
+    "nicknames": [
+      "Necrolilith"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "rivalry"
+        ],
+        "items": [
+          "murkycapsule"
+        ],
+        "moves": [
+          "cbt",
+          "infernalblade",
+          "samuraiedge"
+        ],
+        "lockedMoves": [
+          "enviousrage",
+          "malaria"
         ],
         "level": 84
       }
@@ -7035,6 +8089,63 @@
           "bulletseed"
         ],
         "level": 84
+      }
+    ]
+  },
+  "twinztwo": {
+    "nicknames": [
+      "Check Em"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "scrappy"
+        ],
+        "items": [
+          "angelpowder",
+          "heavydutyboots",
+          "lifeorb"
+        ],
+        "moves": [
+          "dualchaos",
+          "dualdivinity",
+          "bonemerang",
+          "doublenote",
+          "chainsawrun",
+          "tictoc"
+        ],
+        "lockedMoves": [
+          "doublehit"
+        ],
+        "level": 88
+      }
+    ]
+  },
+  "twinz": {
+    "nicknames": [
+      "Dubus"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "levitate"
+        ],
+        "items": [
+          "angelpowder",
+          "heavydutyboots",
+          "lifeorb"
+        ],
+        "moves": [
+          "geargrind",
+          "dualchop",
+          "doublekick",
+          "elegy",
+          "painsplit"
+        ],
+        "lockedMoves": [
+          "doublehit"
+        ],
+        "level": 88
       }
     ]
   },
@@ -7871,6 +8982,30 @@
       }
     ]
   },
+  "gothot": {
+    "nicknames": [
+      "Gothot"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "vespertine"
+        ],
+        "items": [
+          "murkycapsule"
+        ],
+        "moves": [
+          "copycat",
+          "painsplit"
+        ],
+        "lockedMoves": [
+          "seduction",
+          "essencedrain"
+        ],
+        "level": 84
+      }
+    ]
+  },
   "wtrevenant": {
     "nicknames": [
       "WackTrevor"
@@ -7946,6 +9081,60 @@
         "lockedMoves": [
           "shadowstrike",
           "trickortreat"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "torappu": {
+    "nicknames": [
+      "100% Female"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "constrictor"
+        ],
+        "items": [
+          "bindingband"
+        ],
+        "moves": [
+          "cbt",
+          "odynocharge",
+          "glitzblitz",
+          "hiphiphooray",
+          "bind"
+        ],
+        "lockedMoves": [
+          "seduction",
+          "claustrogrip"
+        ],
+        "level": 84
+      }
+    ]
+  },
+  "toyagumon": {
+    "nicknames": [
+      "ToyAgumon"
+    ],
+    "sets": [
+      {
+        "abilities": [
+          "filter"
+        ],
+        "items": [
+          "heavydutyboots",
+          "angelpowder",
+          "lifeorb"
+        ],
+        "moves": [
+          "legotrap",
+          "technorush",
+          "fireblast"
+        ],
+        "lockedMoves": [
+          "toyflame",
+          "gigabyte"
         ],
         "level": 84
       }

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -36745,7 +36745,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		name: "Encrypt",
 		pp: 10,
 		priority: 4,
-		flags: {},
+		volatileStatus: 'protect',
+		onPrepareHit(pokemon) {
+			return !!this.queue.willAct() && this.runEvent('StallMove', pokemon);
+		},
+		onHit(pokemon) {
+			pokemon.addVolatile('stall');
+		},
+		flags: {noassist: 1, failcopycat: 1},
 		secondary: null,
 		target: "self",
 		type: "Cyber",
@@ -49135,7 +49142,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			self: {
+				boosts: {
+					spe: 1,
+				},
+			},
+		},
 		target: "normal",
 		type: "Flying",
 		isNonstandard: "Future",
@@ -50155,7 +50169,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
-		secondary: null,
+		secondary: {
+			chance: 25,
+			self: {
+				boosts: {
+					atk: 1,
+				},
+			},
+		},
 		critRatio: 2,
 		target: "normal",
 		type: "Steel",
@@ -57892,9 +57913,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {contact: 1, protect: 1, reflectable: 1, mirror: 1},
-		secondary: null,
-		boosts: {
-			accuracy: 1,
+		secondary: {
+			chance: 100,
+			self: {
+				boosts: {
+					accuracy: 1,
+				},
+			},
 		},
 		target: "normal",
 		type: "Steel",
@@ -61091,6 +61116,21 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {pulse: 1},
+		onHitField(target, source) {
+			const targets: Pokemon[] = [];
+			let anyAirborne = false;
+			for (const pokemon of this.getAllActive()) {
+				
+				if (pokemon.hasType('Grass')) {
+					// This move affects every grounded Grass-type Pokemon in play.
+					targets.push(pokemon);
+				}
+			}
+			if (!targets.length) return false; // Fails when there are no grounded Grass types or airborne Pokemon
+			for (const pokemon of targets) {
+				this.boost({atk: 1, spa: 1}, pokemon, source);
+			}
+		},
 		secondary: null,
 		target: "scripted",
 		type: "Bug",
@@ -68437,7 +68477,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1},
 		boosts: {
-			def: 2,
+			spd: 2,
 		},
 		secondary: null,
 		target: "self",
@@ -68453,7 +68493,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 20,
+			volatileStatus: 'confusion',
+		},
 		target: "normal",
 		type: "Glass",
 		isNonstandard: "Future",
@@ -74568,7 +74611,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, defrost: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'brn',
+		},
 		target: "normal",
 		type: "Plastic",
 		isNonstandard: "Future",
@@ -76617,6 +76663,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
+		onBasePower(basePower, pokemon) {
+			if (['hail', 'snow'].includes(pokemon.effectiveWeather())) {
+				return this.chainModify(2);
+			}
+		},
 		secondary: null,
 		target: "normal",
 		type: "Ice",
@@ -76818,6 +76869,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, sound: 1},
+		onBasePower(basePower, pokemon) {
+			if (['hail', 'snow'].includes(pokemon.effectiveWeather())) {
+				return this.chainModify(2);
+			}
+		},
 		secondary: null,
 		target: "normal",
 		type: "Ice",
@@ -78598,7 +78654,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'tox',
+		},
 		target: "normal",
 		type: "Cosmic",
 		isNonstandard: "Future",
@@ -80308,7 +80367,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'par',
+		},
 		target: "normal",
 		type: "Virus",
 		isNonstandard: "Future",
@@ -80621,7 +80683,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		onEffectiveness(typeMod, target, type) {
+			if (type === 'Fairy') return 1;
+		},
+		secondary: {
+			chance: 15,
+			status: 'psn',
+		},
 		target: "normal",
 		type: "Dragon",
 		isNonstandard: "Future",
@@ -81609,15 +81677,15 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (attacker.gender && defender.gender) {
 				if (attacker.gender === defender.gender) {
 					this.debug('Rivalry boost');
-					return this.chainModify(1.75);
+					return this.chainModify(0.75);
 				} else {
 					this.debug('Rivalry weaken');
-					return this.chainModify(0.75);
+					return this.chainModify(1.75);
 				}
 			}
 		},
 		onDamagingHit(damage, target, source, move) {
-			if (this.checkMoveMakesContact(move, source, target)) {
+			 {
 				if (this.randomChance(3, 10)) {
 					source.addVolatile('attract', this.effectState.target);
 				}
@@ -85127,6 +85195,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, west: 1},
+		onEffectiveness(typeMod, target, type) {
+			if (type === 'Dark') return 1;
+		},
 		secondary: null,
 		target: "normal",
 		type: "Tech",
@@ -88244,7 +88315,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			volatileStatus: 'confusion',
+		},
 		target: "normal",
 		type: "Shadow",
 		isNonstandard: "Future",
@@ -90288,6 +90362,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		secondary: null,
+		onEffectiveness(typeMod, target, type) {
+			if (type === 'Dark') return 1;
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -90402,6 +90479,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, sound: 1},
+		onEffectiveness(typeMod, target, type) {
+			if (type === 'Dark') return 1;
+		},
 		secondary: null,
 		target: "allAdjacentFoes",
 		type: "Sound",
@@ -90948,6 +91028,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
 		secondary: null,
+		onEffectiveness(typeMod, target, type) {
+			if (type === 'Dark') return 1;
+		},
 		target: "allAdjacentFoes",
 		type: "Divine",
 		isNonstandard: "Future",


### PR DESCRIPTION
Moves: glasssparkle, Bellerophon, Numbing Injection, Jyu O Hanketsu, Justice Bullet, HOEMARU, CUSTOSMORUM, Subzero Wail, Glacial Rend, SHADOW, Samurai Edge

Randbat mons: Rlimshaikworm, Eihortli, Acrylomodo, Nukrylic, Painter, Glassbol, Maglamp, Alolan Togekiss, White Door, Ahchah, Berserkalot, Rideusa, Nexaphago, Autisma, Nursebola, Splague, Hunballun, Bigmallow, Baxbak, Sloggeroth, Paintip, Twinztwo, Twinz, Elsnow, Wymaiden, Gothot, torappu, Necroseel, Doomsay, gigagigerth, ToyAgumon, clamppelo, Monster Pain, Fissiom, Bleedtoise, Necrolilith, Harcanine, Ionnine, Mechaking, Mecharbok