### PR TITLE
[CAP] regigigone nerf

### DIFF
--- a/data/mods/clovercap/moves.ts
+++ b/data/mods/clovercap/moves.ts
@@ -833,6 +833,17 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 	},
 	ragefist: {
 		inherit: true,
+		basePowerCallback(pokemon) {
+			return Math.min(200, 50 + 25 * pokemon.timesAttacked);
+		},
+		category: "Physical",
+		name: "Rage Fist",
+		pp: 10,
+		priority: 0,
+		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
+		secondary: null,
+		target: "normal",
+		type: "Ghost",
 		isNonstandard: null,
 		noSketch: true,
 	},

--- a/data/mods/clovercap/text/moves.ts
+++ b/data/mods/clovercap/text/moves.ts
@@ -91,4 +91,9 @@ export const MovesText: {[k: string]: ModdedMoveText} = {
 		desc: "Has a 10% chance to lower the target's Special Defense by 1 stage. This move's type effectiveness against Steel is changed to be super effective no matter what this move's type is.",
 		shortDesc: "10% chance to lower the target's Sp. Def by 1. Super effective on Steel.",
 	},
+	ragefist: {
+		inherit: true,
+		desc: "Power is equal to 50+(X*25), where X is the total number of times the user has been hit by a damaging attack during the battle, even if the user did not lose HP from the attack. X cannot be greater than 6 and does not reset upon switching out or fainting. Each hit of a multi-hit attack is counted, but confusion damage is not counted.",
+		shortDesc: "+25 power for each time user was hit. Max 6 hits.",
+	}
 };


### PR DESCRIPTION
Removes Bulk Up from Regigigone.
Nerfs Rage Fist in CAP to only go up +25 each hit, to a maximum of 200BP at 6 hits.