### PR TITLE
fix - adjustment to the Mind Corruption skill

### DIFF
--- a/data/mods/wack/conditions.ts
+++ b/data/mods/wack/conditions.ts
@@ -865,7 +865,7 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 		onModifyAccuracy(accuracy) {
 			if (typeof accuracy !== 'number') return;
 			this.debug('megax - decreasing accuracy');
-			return this.chainModify(0.4);
+			return this.chainModify(0.3);
 		},
 	},
 	
@@ -921,9 +921,19 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 	},
 
 	maltina:{
-		onStart(source) {
-			this.field.setWeather('snow');
-		},
+		onFoeTryMove(target, source, move) {
+			const targetAllExceptions = ['perishsong', 'flowershield', 'rototiller'];
+			if (move.target === 'foeSide' || (move.target === 'all' && !targetAllExceptions.includes(move.id))) {
+				return;
+			}
+
+			const dazzlingHolder = this.effectState.target;
+			if ((source.isAlly(dazzlingHolder) || move.target === 'all') && move.priority > 0.1) {
+				this.attrLastMove('[still]');
+				this.add('cant', dazzlingHolder, 'ability: Dazzling', move, '[of] ' + target);
+				return false;
+			}
+		}
 	}, 
 
 	mentum:{


### PR DESCRIPTION
fix - adjustment to the Mind Corruption skill

## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities