### PR TITLE
adjustment in the naming of the type of Over Heaven pokemon

### DIFF
--- a/data/pokedex.ts
+++ b/data/pokedex.ts
@@ -53474,7 +53474,7 @@ tamanaut: {
 	overheaven: { 
 		num: -50027,
 		name: "Over Heaven",
-		types: ["Light", "Fight"],
+		types: ["Light", "Fighting"],
 		gender: "M", 
 		baseStats: {hp: 100, atk: 120, def: 80, spa: 50, spd: 80, spe: 110},
 		abilities: {0: "Lockdown", 1: "Download"},


### PR DESCRIPTION
adjustment in the naming of the type of Over Heaven pokemon

## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities