### PR TITLE
Filling in the data formats of new ocb pokemons

### DIFF
--- a/data/formats-data.ts
+++ b/data/formats-data.ts
@@ -11467,6 +11467,30 @@ export const FormatsData: { [k: string]: SpeciesFormatsData } = {
 		tier: "Illegal",
 		isNonstandard: "Future",
 	},
+	aethernox: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	ilusionist: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	zephandor: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	ragnarith: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	omnirath: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
+	drakorion: {
+		tier: "Illegal",
+		isNonstandard: "Future",
+	},
 	blobbosswitch: {
 		tier: "Illegal",
 		isNonstandard: "Future",


### PR DESCRIPTION
Filling in the data formats of new ocb pokemons

## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities