### PR TITLE
innate abilities of new ocb boss pokemons, default

### DIFF
--- a/data/mods/wack/conditions.ts
+++ b/data/mods/wack/conditions.ts
@@ -1147,7 +1147,102 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			pokemon.trapped = false;
 			this.add('-message', `${pokemon.name} é imune a efeitos de aprisionamento devido ao roubo de Ungoldbr!`);
 		},
-	}
+	},
+	aethernox:{
+		onTrapPokemon(pokemon) {
+			pokemon.trapped = false;
+		  },
+		  onFlinch(target) {
+			return false;
+		  },
+		  onUpdate(pokemon) {
+			if (pokemon.volatiles['confusion']) {
+			  pokemon.removeVolatile('confusion');
+			  this.add('-end', pokemon, 'confusion', '[from] ability: Autoridade Suprema');
+			}
+		  },
+		  onFoeModifyMove(move, target) {
+			if (move.priority > 0) {
+			  move.accuracy = 50;
+			}
+		  }
+	},
+	drakorion:{
+		onTrapPokemon(pokemon) {
+			pokemon.trapped = false;
+		  },
+		  onFlinch(target) {
+			return false;
+		  },
+		  onUpdate(pokemon) {
+			if (pokemon.volatiles['confusion']) {
+			  pokemon.removeVolatile('confusion');
+			  this.add('-end', pokemon, 'confusion', '[from] ability: Autoridade Suprema');
+			}
+		  },
+		  onFoeModifyMove(move, target) {
+			if (move.priority > 0) {
+			  move.accuracy = 50;
+			}
+		  }
+	},
+	omnirath:{
+		onTrapPokemon(pokemon) {
+			pokemon.trapped = false;
+		  },
+		  onFlinch(target) {
+			return false;
+		  },
+		  onUpdate(pokemon) {
+			if (pokemon.volatiles['confusion']) {
+			  pokemon.removeVolatile('confusion');
+			  this.add('-end', pokemon, 'confusion', '[from] ability: Autoridade Suprema');
+			}
+		  },
+		  onFoeModifyMove(move, target) {
+			if (move.priority > 0) {
+			  move.accuracy = 50;
+			}
+		  }
+	},
+	ragnarith:{
+		onTrapPokemon(pokemon) {
+			pokemon.trapped = false;
+		  },
+		  onFlinch(target) {
+			return false;
+		  },
+		  onUpdate(pokemon) {
+			if (pokemon.volatiles['confusion']) {
+			  pokemon.removeVolatile('confusion');
+			  this.add('-end', pokemon, 'confusion', '[from] ability: Autoridade Suprema');
+			}
+		  },
+		  onFoeModifyMove(move, target) {
+			if (move.priority > 0) {
+			  move.accuracy = 50;
+			}
+		  }
+	},
+	zephandor:{
+		onTrapPokemon(pokemon) {
+			pokemon.trapped = false;
+		  },
+		  onFlinch(target) {
+			return false;
+		  },
+		  onUpdate(pokemon) {
+			if (pokemon.volatiles['confusion']) {
+			  pokemon.removeVolatile('confusion');
+			  this.add('-end', pokemon, 'confusion', '[from] ability: Autoridade Suprema');
+			}
+		  },
+		  onFoeModifyMove(move, target) {
+			if (move.priority > 0) {
+			  move.accuracy = 50;
+			}
+		  }
+	},
 
 
 


### PR DESCRIPTION
innate abilities of new ocb boss pokemons, default

## Description
Describe what you're doing here please

## Checklist
- [ ] Added entries to `data/formats-data.ts` for any newly added Pokémon to make them illegal by default
- [ ] Added entries to `data/mod/<YOUR MOD HERE>/formats-data.ts` to make any newly added Pokémon legal
- [ ] Added `isNonstandard: "Future"` to any newly added moves, items, or abilities