### PR TITLE
Wack Thanksgiving update

### DIFF
--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -15264,6 +15264,11 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 				return null;
 			}
 		},
+		onModifySpe(spe, pokemon) {
+			if (this.field.getPseudoWeather('feast')) {
+				return this.chainModify(2);
+			}
+		},
 		name: "Sugar Rush",
 		rating: 3,
 		num: 6693,

--- a/data/conditions.ts
+++ b/data/conditions.ts
@@ -963,6 +963,31 @@ export const Conditions: {[k: string]: ConditionData} = {
 			this.add('-end', pokemon, 'Flammable');
 		},
 	},
+	icing: {
+		name: 'icing',
+		onStart(pokemon) {
+			this.add('-start', pokemon, 'Icing');
+		},
+		duration: 3,
+		durationCallback(target, source, effect) {
+			if (effect?.name === "Icing Cannon" ||effect?.name === "Icing CannoSpraynh" ) {
+				return 2;
+			}
+			if (effect?.name === "Archbtyrophbia") {
+				return 4;
+			}
+			return 3;
+		},
+		onSourceModifyDamage(damage, source, target, move) {
+			let mod = 1;
+			if (move.type === 'Food') mod *= 1.5;
+
+			return this.chainModify(mod);
+		},
+		onEnd(pokemon) {
+			this.add('-end', pokemon, 'Icing');
+		},
+	},
 	statusguard: {
 		name: 'statusguard',
 		onStart(pokemon) {

--- a/data/mods/wack/abilities.ts
+++ b/data/mods/wack/abilities.ts
@@ -307,6 +307,14 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 		desc: "The power of Fire and Magma-type attacks against this Pokemon is halved. This Pokemon takes half of the usual burn damage, rounded down.",
 		shortDesc: "The power of Fire and Magma-type attacks against this Pokemon is halved; burn damage halved.",
 	},
+	infiltrator: {
+		inherit: true,
+		onModifyMove(move) {
+			move.infiltrates = true;
+		},
+		name: "Infiltrator",
+		isNonstandard: null,
+	},
 	scrappy: {
 		inherit: true,
 		onModifyMove(move) {

--- a/data/mods/wack/conditions.ts
+++ b/data/mods/wack/conditions.ts
@@ -245,6 +245,97 @@ export const Conditions: {[k: string]: ModdedConditionData} = {
 			}
 		},
 	},
+	himwood: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('arboreum')) {
+				this.field.addPseudoWeather('arboreum');
+			}
+		},
+	},
+	himsteam: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('sauna')) {
+				this.field.addPseudoWeather('sauna');
+			}
+		},
+	},
+	himwind: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('tempest')) {
+				this.field.addPseudoWeather('tempest');
+			}
+		},
+	},
+	himtech: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('factory')) {
+				this.field.addPseudoWeather('factory');
+			}
+		},
+	},
+	himdragon: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('dragonruins')) {
+				this.field.addPseudoWeather('dragonruins');
+			}
+		},
+	},
+	himvirus: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('pandemic')) {
+				this.field.addPseudoWeather('pandemic');
+			}
+		},
+	},
+	himfood: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('feast')) {
+				this.field.addPseudoWeather('feast');
+			}
+		},
+	},
+	himzombie: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('graveyard')) {
+				this.field.addPseudoWeather('graveyard');
+			}
+		},
+	},
+	himmagic: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('manaverse')) {
+				this.field.addPseudoWeather('manaverse');
+			}
+		},
+	},
+	himghost: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('spiritstorm')) {
+				this.field.addPseudoWeather('spiritstorm');
+			}
+		},
+	},
+	himcosmic: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('starfield')) {
+				this.field.addPseudoWeather('starfield');
+			}
+		},
+	},
+	himcyber: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('cyberspace')) {
+				this.field.addPseudoWeather('cyberspace');
+			}
+		},
+	},
+	himnuclear: {
+		onSwitchIn(pokemon) {
+			if (!this.field.getPseudoWeather('fallout')) {
+				this.field.addPseudoWeather('fallout');
+			}
+		},
+	},
 	tapubulu: {
 		onSwitchIn(pokemon) {
 			if (!this.field.isTerrain('grassyterrain')) {

--- a/data/mods/wack/formats-data.ts
+++ b/data/mods/wack/formats-data.ts
@@ -1441,7 +1441,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	slaking: {
 		inherit: true,
-		tier: "UU",
+		tier: "UUBL",
 		isNonstandard: null,
 	},
 	nincada: {
@@ -1906,12 +1906,12 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	kyogre: {
 		inherit: true,
-		tier: "UU",
+		tier: "UUBL",
 		isNonstandard: null,
 	},
 	groudon: {
 		inherit: true,
-		tier: "UU",
+		tier: "UUBL",
 		isNonstandard: null,
 	},
 	rayquaza: {
@@ -27222,7 +27222,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	bgroudon: {
 		inherit: true,
-		tier: "UU",
+		tier: "UUBL",
 		isNonstandard: null,
 	},
 	btreecko: {
@@ -27327,12 +27327,12 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	fgroudon: {
 		inherit: true,
-		tier: "UU",
+		tier: "UUBL",
 		isNonstandard: null,
 	},
 	fkyogre: {
 		inherit: true,
-		tier: "UU",
+		tier: "UUBL",
 		isNonstandard: null,
 	},
 	cmsnivy: {

--- a/data/mods/wack/moves.ts
+++ b/data/mods/wack/moves.ts
@@ -1583,8 +1583,22 @@ export const Moves: {[k: string]: ModdedMoveData} = {
 		type: "Bone",
 		isNonstandard: null,
 	},
+	
 	hyperspacefury: {
 		inherit: true,
+		desc: "Lowers the user's Defense by 1 stage. This move cannot be used by a Hoopa unless its current form, while considering Transform, is Hoopa Unbound. If this move is successful, it breaks through the target's Baneful Bunker, Detect, King's Shield, Protect, or Spiky Shield for this turn, allowing other Pokemon to attack the target normally. If the target's side is protected by Crafty Shield, Mat Block, Quick Guard, or Wide Guard, that protection is also broken for this turn and other Pokemon may attack the target's side normally.",
+		shortDesc: "Lowers user's Def by 1; breaks protect.",
+		onTry(source) {
+			if (source.species.baseSpecies === 'Hoopa') {
+				if (source.species.name === 'Hoopa-Unbound') {
+					return;
+				}
+
+				this.attrLastMove('[still]');
+				this.add('-fail', source, 'move: Hyperspace Fury', '[forme]');
+				return null;
+			}
+		},
 		type: "Cosmic",
 		category: "Special",
 		flags: {},

--- a/data/mods/wack/random-sets.json
+++ b/data/mods/wack/random-sets.json
@@ -6846,7 +6846,7 @@
         ],
         "moves": [
           "claustrocrush",
-          "stealrock",
+          "stealthrock",
           "rockgather"
         ],
         "lockedMoves": [
@@ -16576,7 +16576,7 @@
         ],
         "lockedMoves": [
           "flareblitz",
-          "avarice"
+          "aichmoclaws"
         ],
         "level": 84
       }

--- a/data/mods/wackclover/learnsets.ts
+++ b/data/mods/wackclover/learnsets.ts
@@ -4610,6 +4610,7 @@ bloodhound: ["8L1"],
 	},
 	anaconduke: {
 		learnset: {
+			greenthumb: ["8L1"],
 			serpentwhip: ["8L1"],
 bask: ["8L1"],
 powerarena: ["8L1"],
@@ -4787,6 +4788,7 @@ achillesheel: ["8L1"],
 	},
 	sjwhale: {
 		learnset: {
+			sauna: ["8L1"],
 			steamspout: ["8L1"],
 			subzerowail: ["8L1"],
 geyser: ["8L1"],
@@ -6030,6 +6032,7 @@ bonebreaker: ["8L1"],
 	},
 	urswine: {
 		learnset: {
+			feast: ["8L1"],
 			baconrush: ["8L1"],
 			greasygrasp: ["8L1"],
 			greasyslap: ["8L1"],
@@ -6482,7 +6485,7 @@ triplenote: ["8L1"],
 			retaliatespell: ["8L1"],
 			spellslash: ["8L1"],
 			hexclaw: ["8L1"],
-			
+			manaverse: ["8L1"],
 shadowchill: ["8L1"],
 shadowbolt: ["8L1"],
 shadowbreak: ["8L1"],
@@ -7909,6 +7912,7 @@ zombiehorde: ["8L1"],
 	},
 	octai: {
 		learnset: {
+			sauna: ["8L1"],
 			squirtcannon: ["8L1"],
 			lifedew: ["8L1"],
 			coralreef: ["8L1"],
@@ -10019,6 +10023,7 @@ summonhorrors: ["8L1"],
 	},
 	whizzard: {
 		learnset: {
+			manaverse: ["8L1"],
 			coneofcold: ["8L1"],
 			bindingcircle: ["8L1"],
 sappingspell: ["8L1"],
@@ -12117,6 +12122,7 @@ flavortown: ["8L1"],
 	},
 	cannonance: {
 		learnset: {
+			factory: ["8L1"],
 			technoray: ["8L1"],
 			fearpulse: ["8L1"],
 			lightpulse: ["8L1"],
@@ -12349,6 +12355,7 @@ lanceoflonginus: ["8L1"],
 	},
 	foryu: {
 		learnset: {
+			bodybreak: ["8L1"],
 			necksnap: ["8L1"],
 			bladerain: ["8L1"],
 magnetforce: ["8L1"],
@@ -15257,6 +15264,7 @@ bodyboost: ["8L1"],
 	},
 	nomaestro: {
 		learnset: {
+			detonationburst: ["8L1"],
 			highnote: ["8L1"],
 			soniccharge: ["8L1"],
 swansong: ["8L1"],
@@ -16013,6 +16021,7 @@ injector: ["8L1"],
 	},
 	sonnanos: {
 		learnset: {
+			factory: ["8L1"],
 			nanobotbarrier: ["8L1"],
 			shieldmode: ["8L1"],
 			randommode: ["8L1"],
@@ -16497,10 +16506,12 @@ acidrain: ["8L1"],
 	},
 	hitmonana: {
 		learnset: {
+			feast: ["8L1"],
 			fruityburst: ["8L1"],
 fruitpunch: ["8L1"],
 bananapeel: ["8L1"],
 bananarang: ["8L1"],
+greenthumb: ["8L1"],
 			armthrust: ["8L7"],
 			attract: ["8M"],
 			aurasphere: ["8L39"],
@@ -20626,6 +20637,7 @@ meltedplastic: ["8L1"],
 	},
 	spookzilla: {
 		learnset: {
+			graveyard: ["8L1"],
 			skullbash: ["8L1"],
 			aerialace: ["8M"],
 			astonish: ["8L1"],
@@ -21254,6 +21266,10 @@ sugarrush: ["8L1"],
 	},
 	farfigtron: {
 		learnset: {
+			powerarena: ["8L1"],
+			bodyboost: ["8L1"],
+			magmacannon: ["8L1"],
+			dropguard: ["8L1"],
 			aerialace: ["8M"],
 			agility: ["8L23"],
 			attract: ["8M"],
@@ -23317,6 +23333,7 @@ cbt: ["8L1"],
 		learnset: {
 			toxicsteamtackle: ["8L1"],
 			hotpocketcrash: ["8L1"],
+			magmacannon: ["8L1"],
 steamsale: ["8L1"],
 ashrain: ["8L1"],
 technorush: ["8L1"],
@@ -27278,6 +27295,8 @@ crystalize: ["8L1"],
 	},
 	faptime: {
 		learnset: {
+			sauna: ["8L1"],
+			fastforward: ["8L1"],
 			ballbreaker: ["8L1"],
 rubout: ["8L1"],
 edging: ["8L1"],
@@ -27536,10 +27555,21 @@ heavenshole: ["8L1"],
 	},
 	dedwheat: {
 		learnset: {
+			agingburst: ["8L1"],
+			consume: ["8L1"],
+			rottingburst: ["8L1"],
+			infect: ["8L1"],
+			undeadrespite: ["8L1"],
+			corpsewave: ["8L1"],
+			zombiebile: ["8L1"],
+			decaytouch: ["8L1"],
+			feast: ["8L1"],
+			moldburst: ["8L1"],
 			sandwichstack: ["8L1"],
 			foodpoison: ["8L1"],
 wildmushroom: ["8L1"],
 acidrain: ["8L1"],
+compost: ["8L1"],
 			block: ["8T"],
 			bodyslam: ["8T"],
 			bulletseed: ["8M"],
@@ -30222,6 +30252,7 @@ amberwave:["8L1"],
 	},
 	quiboom: {
 		learnset: {
+			sauna: ["8L1"],
 			acid: ["8E"],
 			acidarmor: ["8E"],
 			acidspray: ["8E"],
@@ -30251,6 +30282,7 @@ amberwave:["8L1"],
 	},
 	gynuke: {
 		learnset: {
+			sauna: ["8L1"],
 			steambomb: ["8L1"],
 			nuclearexplosion: ["8L1"],
 			atomicrush: ["8L1"],
@@ -32351,6 +32383,7 @@ daydream: ["8L1"],
 	},
 	tarditank: {
 		learnset: {
+			sauna: ["8L1"],
 			hightide: ["8L1"],
 			aquaring: ["8T"],
 			attract: ["8M"],

--- a/data/mods/wackclover/moves.ts
+++ b/data/mods/wackclover/moves.ts
@@ -2432,6 +2432,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: null,
 		},
+		agingburst: {
+		inherit: true,
+		isNonstandard: null,
+		},
 		aichmoclaws: {
 			inherit: true,
 			isNonstandard: null,
@@ -2780,6 +2784,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		isNonstandard: null,
 		},
 		bodyboost: {
+		inherit: true,
+		isNonstandard: null,
+		},
+		bodybreak: {
 		inherit: true,
 		isNonstandard: null,
 		},
@@ -4263,7 +4271,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: null,
 		},
-		
+		magmacannon: {
+		inherit: true,
+		isNonstandard: null,
+		},
 		magmaquake: {
 			inherit: true,
 			isNonstandard: null,
@@ -4432,6 +4443,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		mochihammer: {
 		inherit: true,
 		flags: {contact: 1, protect: 1, mirror: 1, hammer: 1},
+		isNonstandard: null,
+		},
+		moldburst: {
+		inherit: true,
 		isNonstandard: null,
 		},
 		mosaicray: {
@@ -4855,6 +4870,14 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		isNonstandard: null,
 		},
 		rockgather: {
+		inherit: true,
+		isNonstandard: null,
+		},
+		rocketjumpkick: {
+		inherit: true,
+		isNonstandard: null,
+		},
+		rottingburst: {
 		inherit: true,
 		isNonstandard: null,
 		},
@@ -5350,6 +5373,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		isNonstandard: null,
 		},
 		stuffedtackle: {
+		inherit: true,
+		isNonstandard: null,
+		},
+		sauna: {
 		inherit: true,
 		isNonstandard: null,
 		},
@@ -5856,6 +5883,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		isNonstandard: null,
 		},
 		zombiebite: {
+		inherit: true,
+		isNonstandard: null,
+		},
+		zombiebile: {
 		inherit: true,
 		isNonstandard: null,
 		},

--- a/data/mods/wackclover/pokedex.ts
+++ b/data/mods/wackclover/pokedex.ts
@@ -332,7 +332,7 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	},
 	hohohoming: {
 		inherit: true,
-		types: ["Ice", "tech"],
+		types: ["Ice", "Tech"],
 		
 	},
 	huntabre: {
@@ -548,7 +548,7 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 	},
 	dedwheat: {
 		inherit: true,
-		types: ["Poison", "Food"],
+		types: ["Zombie", "Food"],
 	},
 	maripyro: {
 		inherit: true,

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -35972,6 +35972,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1},
+		boosts: {
+			atk: -2,
+			spa: -2,
+		},
 		secondary: null,
 		target: "normal",
 		type: "Rubber",
@@ -45630,7 +45634,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, defrost: 1},
-		secondary: null,
+		secondary: {
+			chance: 50,
+			status: 'brn',
+		},
 		target: "normal",
 		type: "Grass",
 		isNonstandard: "Future",
@@ -45901,10 +45908,40 @@ export const Moves: {[moveid: string]: MoveData} = {
 		accuracy: true,
 		basePower: 1,
 		category: "Physical",
+		noPPBoosts: true,
 		name: "Crumbs",
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
+		basePowerCallback(source, target, move) {
+			const callerMoveId = move.sourceEffect || move.id;
+			const moveSlot = callerMoveId === 'instruct' ? source.getMoveData(move.id) : source.getMoveData(callerMoveId);
+			let bp;
+			if (!moveSlot) {
+				bp = 40;
+			} else {
+				switch (moveSlot.pp) {
+				case 0:
+					bp = 200;
+					break;
+				case 1:
+					bp = 80;
+					break;
+				case 2:
+					bp = 60;
+					break;
+				case 3:
+					bp = 50;
+					break;
+				default:
+					bp = 40;
+					break;
+				}
+			}
+
+			this.debug('BP: ' + bp);
+			return bp;
+		},
 		secondary: null,
 		target: "normal",
 		type: "Food",
@@ -53452,6 +53489,41 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {},
+		pseudoWeather: 'fallout',
+		condition: {
+			duration: 5,
+			durationCallback(target, source, effect) {
+				if (source?.hasItem('radioactiverock')|| source?.hasAbility(['persistent', 'moreroom', 'builder'])) {
+					return 10;
+				}
+				return 5;
+			},
+			onFieldStart(field, source) {
+				this.add('-fieldstart', 'move: Fallout', '[of] ' + source);
+			},
+			onBasePowerPriority: 1,
+			onBasePower(basePower, attacker, defender, move) {
+				if (move.type === 'Nuclear') {
+					this.debug('fallout increase');
+					return this.chainModify([1.3]);
+				}
+			},
+			onResidualOrder: 6,
+			onResidual(pokemon) {
+				if (pokemon.hasItem('hazmatsuit')) return;
+				else if (pokemon.hasType('Nuclear')) {
+
+				this.heal(pokemon.baseMaxhp / 13);
+			}
+				else this.damage(pokemon.baseMaxhp / 10);
+			},
+			
+			onFieldResidualOrder: 27,
+			onFieldResidualSubOrder: 4,
+			onFieldEnd() {
+				this.add('-fieldend', 'move: Fallout');
+			},
+		},
 		secondary: null,
 		target: "allySide",
 		type: "Nuclear",
@@ -60107,7 +60179,40 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 40,
+			onHit(target, source) {
+				if (source.hasType('Fighting')) {
+					this.boost({atk: 1}, source, source);
+				} else if (source.hasType('Flying')) {
+					this.boost({spe: 1}, source, source);
+				} else if (source.hasType('Rubber')) {
+					this.boost({spd: 1}, source, source);
+				} else if (source.hasType('Rock')) {
+					this.boost({def: 1}, source, source);
+				} else if (source.hasType('Fire')) {
+					target.trySetStatus('brn', source);
+				} else if (source.hasType('Electric')) {
+					target.trySetStatus('par', source);
+				} else if (source.hasType('Ice')) {
+					target.trySetStatus('frz', source);
+				} else if (source.hasType('Poison')) {
+					target.trySetStatus('tox', source);
+				} else if (source.hasType('Nuclear')) {
+					target.trySetStatus('tox', source);
+				} else if (source.hasType('Cosmic')) {
+					target.trySetStatus('slp', source);
+				} else if (source.hasType('Heart')) {
+					target.addVolatile('attract');
+				} else if (source.hasType('Fairy')) {
+					target.addVolatile('attract');
+				} else if (source.hasType('Psychic')) {
+					target.addVolatile('confusion');
+				} else if (source.hasType('Water')) {
+					this.boost({spe: -1}, target, source);
+			}
+		},
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -63987,7 +64092,19 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		onTry() {
+			return !this.field.isTerrain('grassyterrain');
+		},
+		onHit() {
+			this.field.clearTerrain();
+		},
+		onAfterSubDamage() {
+			this.field.clearTerrain();
+		},
+		secondary: {
+			chance: 100,
+			status: 'brn',
+		},
 		target: "normal",
 		type: "Grass",
 		isNonstandard: "Future",
@@ -65882,7 +65999,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			boosts: {
+				accuracy: -1,
+			},
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -68180,7 +68302,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (!result) return result;
 			source.statusState.time = 3;
 			source.statusState.startTime = 3;
-			this.heal(source.maxhp); // Aesthetic only as the healing happens after you fall asleep in-game
+			this.heal(source.maxhp, source, target); // Aesthetic only as the healing happens after you fall asleep in-game
 		},
 		secondary: null,
 		target: "allAdjacentFoes",
@@ -71393,7 +71515,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 35,
+			status: 'psn',
+		},
 		target: "normal",
 		type: "Grass",
 		isNonstandard: "Future",
@@ -73702,7 +73827,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			onHit(target) {
+				target.addVolatile('icing');
+			},
+		},
 		target: "normal",
 		type: "Fear",
 		isNonstandard: "Future",
@@ -74312,6 +74442,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
+		onEffectiveness(typeMod, target, type) {
+			if (type === 'Bug') return 1;
+		},
 		secondary: null,
 		target: "normal",
 		type: "Grass",
@@ -76192,6 +76325,34 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile(move.id)) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
+		condition: {
+			duration: 2,
+			onImmunity(type, pokemon) {
+				if (type === 'sandstorm' || type === 'hail') return false;
+			},
+			onInvulnerability(target, source, move) {
+				if (['earthquake', 'magnitude', 'lavasplash', 'divinequake', 'meteorrain', 'terrakinesis', 'magmaquake', 'lavaquake'].includes(move.id) && !target.hasAbility('Digger')) {
+					return;
+				}
+				return false;
+			},
+			onSourceModifyDamage(damage, source, target, move) {
+				if (move.id === 'earthquake' || move.id === 'magnitude') {
+					return this.chainModify(2);
+				}
+			},
+		},
 		secondary: null,
 		target: "normal",
 		type: "Ground",
@@ -76585,7 +76746,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 20,
+			status: 'brn',
+		},
 		critRatio: 2,
 		target: "normal",
 		type: "Grass",
@@ -78234,6 +78398,18 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile(move.id)) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			this.boost({atk: 1}, attacker, attacker, move);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
 		secondary: null,
 		target: "normal",
 		type: "Food",
@@ -79314,7 +79490,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'psn',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -79640,7 +79819,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			volatileStatus: 'confusion',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -80478,7 +80660,17 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondaries: [
+			{
+				chance: 100,
+				self: {
+					status: 'prz',
+				},
+			}, {
+				chance: 100,
+				status: 'prz',
+			},
+		],
 		target: "normal",
 		type: "Fighting",
 		isNonstandard: "Future",
@@ -80794,6 +80986,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, sound: 1},
 		secondary: null,
+		boosts: {
+			atk: -1,
+			spa: -1,
+		},
 		target: "allAdjacentFoes",
 		type: "Food",
 		isNonstandard: "Future",
@@ -82234,7 +82430,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			status: 'par',
+		},
 		target: "allAdjacentFoes",
 		type: "Food",
 		isNonstandard: "Future",
@@ -82420,6 +82619,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1, punch: 1},
 		secondary: null,
 		target: "normal",
+		multihit: [2, 5],
 		type: "Bug",
 		isNonstandard: "Future",
 	},
@@ -82622,7 +82822,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 40,
+			status: 'brn',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -84040,7 +84243,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		condition: {
 			duration: 5,
 			onFieldStart(field, source) {
-				this.add('-fieldstart', 'move: Magma Sport', '[of] ' + source);
+				this.add('-fieldstart', 'move: Flying Sport', '[of] ' + source);
 			},
 			onBasePowerPriority: 1,
 			onBasePower(basePower, attacker, defender, move) {
@@ -86491,7 +86694,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {snatch: 1},
 		onHit(target, source) {
 			const bestStat = source.getBestStat(true, true);
-			this.boost({[bestStat]: 2}, source);
+			if (this.field.getPseudoWeather('fallout')) {
+				this.boost({[bestStat]: 3}, source);
+				this.directDamage(target.maxhp / 4);}
+				
+				else {
+					this.boost({[bestStat]: 2}, source);
+				}
 		},
 		secondary: null,
 		target: "self",
@@ -86525,6 +86734,36 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {snatch: 1, bite: 1},
+		volatileStatus: 'toxiccoat',
+		condition: {
+			onStart(pokemon, source, effect) {
+				
+					this.add('-start', pokemon, 'ToxicCoat');
+			},
+		onDamagingHitOrder: 1,
+		onDamagingHit(damage, target, source, move) {
+			if (this.checkMoveMakesContact(move, source, target)) {
+				if (this.randomChance(7, 10)) {
+					source.trySetStatus('psn', target);
+					this.add('-message', 'The coat poisoned!');
+				}
+			}
+		},
+			onEnd(pokemon) {
+				this.add('-end', pokemon, 'ToxicCoat', '[silent]');
+			},
+		},
+		onHit(target) {
+			if (this.field.getPseudoWeather('fallout')) {
+				this.boost({
+					spd: 2,
+				});
+			} else {
+				this.boost({
+					spd: 1,
+				});
+			}
+		},
 		secondary: null,
 		target: "self",
 		type: "Nuclear",
@@ -88554,7 +88793,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			volatileStatus: 'confusion',
+		},
 		target: "normal",
 		type: "Fairy",
 		isNonstandard: "Future",
@@ -89191,6 +89433,19 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {snatch: 1, bite: 1},
 		secondary: null,
+		heal: [1, 3],
+		onHit(target) {
+			if (this.field.getPseudoWeather('feast')) {
+				this.boost({
+					spe: 1,
+					def: 1,
+				});
+			} else {
+				this.boost({
+					spe: 1,
+				});
+			}
+		},
 		target: "self",
 		type: "Food",
 		isNonstandard: "Future",
@@ -89556,7 +89811,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			onHit(target) {
+				target.addVolatile('icing');
+			},
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -89570,7 +89830,12 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			onHit(target) {
+				target.addVolatile('icing');
+			},
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -90368,7 +90633,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (!result) return result;
 			source.statusState.time = 3;
 			source.statusState.startTime = 3;
-			this.heal(source.maxhp); // Aesthetic only as the healing happens after you fall asleep in-game
+			this.heal(source.maxhp, source, target); // Aesthetic only as the healing happens after you fall asleep in-game
 		},
 		secondary: null,
 		target: "allAdjacentFoes",
@@ -90442,6 +90707,24 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {snatch: 1},
+		volatileStatus: 'bakingpowderveil',
+		condition: {
+			onStart(pokemon, source, effect) {
+				
+					this.add('-start', pokemon, 'BakingPowderVeil');
+			},
+		onTryHit(target, source, move) {
+			if (target !== source && move.type === 'Fire' || move.type === 'Magma') {
+				if (!this.boost({def: 1})) {
+					this.add('-immune', target, '[from] move: BakingPowderVeil');
+				}
+				return null;
+			}
+		},
+			onEnd(pokemon) {
+				this.add('-end', pokemon, 'BakingPowderVeil', '[silent]');
+			},
+		},
 		secondary: null,
 		target: "allySide",
 		type: "Food",
@@ -91065,7 +91348,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 			if (!result) return result;
 			source.statusState.time = 3;
 			source.statusState.startTime = 3;
-			this.heal(source.maxhp); // Aesthetic only as the healing happens after you fall asleep in-game
+			this.heal(source.maxhp, source, target); // Aesthetic only as the healing happens after you fall asleep in-game
 		},
 		secondary: null,
 		target: "allAdjacentFoes",
@@ -91701,7 +91984,15 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 15,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		onBasePower(basePower, pokemon) {
+			if (['hail', 'snow'].includes(pokemon.effectiveWeather())) {
+				return this.chainModify(2);
+			}
+		},
+		secondary: {
+			chance: 25,
+			status: 'brn',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",
@@ -91783,7 +92074,21 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		onTryMove(attacker, defender, move) {
+			if (attacker.removeVolatile(move.id)) {
+				return;
+			}
+			this.add('-prepare', attacker, move.name);
+			if (!this.runEvent('ChargeMove', attacker, defender, move)) {
+				return;
+			}
+			attacker.addVolatile('twoturnmove', defender);
+			return null;
+		},
+		secondary: {
+			chance: 35,
+			volatileStatus: 'flinch',
+		},
 		critRatio: 2,
 		target: "normal",
 		type: "Food",
@@ -92106,6 +92411,20 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {snatch: 1},
+		onHit(target) {
+			if (this.field.getPseudoWeather('feast')) {
+				this.boost({
+					atk: 2,
+					def: 1,
+					spe: -3,
+				});
+			} else {
+				this.boost({
+					atk: 2,
+					spe: -3,
+				});
+			}
+		},
 		secondary: null,
 		target: "self",
 		type: "Food",
@@ -92450,7 +92769,14 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 100,
+			volatileStatus: 'attract',
+		},
+		onHit(target, source) {
+			if (target.hasType('Grass')) return null;
+			target.addVolatile('leechseed', source);
+		},
 		target: "normal",
 		type: "Grass",
 		isNonstandard: "Future",
@@ -92599,7 +92925,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		secondaries: [
 			{
 				chance: 100,
-				volatileStatus: 'confuse',
+				volatileStatus: 'confusion',
 			}, {
 				chance: 100,
 				volatileStatus: 'attract',
@@ -93250,6 +93576,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1},
+		boosts: {
+			spe: 3,
+		},
 		secondary: null,
 		target: "self",
 		type: "Magic",
@@ -93316,6 +93645,9 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 30,
 		priority: 0,
 		flags: {snatch: 1},
+		boosts: {
+			atk: 2,
+		},
 		secondary: null,
 		target: "self",
 		type: "Magic",
@@ -94715,7 +95047,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
-		secondary: null,
+		secondary: {
+			chance: 30,
+			volatileStatus: 'confusion',
+		},
 		target: "normal",
 		type: "Food",
 		isNonstandard: "Future",


### PR DESCRIPTION
-New Grass Moves
Eighteen Fourteen, Love Seed, Mold Burst, Nettle Knife, Fly Trap, Mow Down -Not Coded Grass Moves Left: Whos On Next, Berry Growth, Berry Drink, Flower Ward, May King, Triple Bananas, Leaf Canopy

-New Food Moves: Secret Ingredient, Raspberry Whistle, Popcorn Blast, Hot Cocoa, BakingPowderVeil (maybe), Icing Spray, Icing Cannon, Gum burst, Eat Dango (1/3 health heal + increases speed), Curry Burst, Force Feed, Crumbs, Spoiled Milk, Sushi Missile, Flour Toss
-Not Coded Food Moves Left: Snack Bait (and related moves), Timbit, Rice Ball, Taco Roll, Bread Rollou

-Various other coded moves: Opulence Catnap clones should now work properly, Burrower Beneath, Archbtyrophbia, Fallout, Toxic Coat, Body Break

-Sugar Rush Now doubles speed in Feast

-HIM Wood, Nuclear, Cyber, GHost, Magic, Virus, Zombie, Food, Dragon, Cosmic, Tech, Wind all set their respective pseudoweathers on switchin now

-Dedwheat made Zombie/Food type and given: Aging burst, CONSUME, rotting burst, infect, undead respite, corpse wave, zombie bile, decay touch, feast -other various moveset additions and fixes for Wack Clover