### PR TITLE
Wack Bans andother minor changes

### DIFF
--- a/config/formats.ts
+++ b/config/formats.ts
@@ -948,7 +948,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet', 'Discombubbles',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'After Image','Perfect Freeze', 'Lunatic Time', 'Electrify + Lightning Rod', 'Electrify + Motor Drive', 'Electrify + Volt Absorb', 'Green Card', 'Time Stasis', 'Suwise Glasses', 'Pressure Orb', 'Training Glove', 'Wire Trap', 'Sketch', 'Soul Barrier',
+			'Hell Drag', 'Pacify', 'Rift Strike', 'Magic Cape', 'After Image','Perfect Freeze', 'Lunatic Time', 'Electrify + Lightning Rod', 'Electrify + Motor Drive', 'Electrify + Volt Absorb', 'Green Card', 'Time Stasis', 'Suwise Glasses', 'Pressure Orb', 'Training Glove', 'Wire Trap', 'Sketch', 'Soul Barrier',
 		],
 	},
 	{
@@ -969,7 +969,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet', 'Discombubbles',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'After Image','Perfect Freeze', 'Electrify + Lightning Rod', 'Electrify + Motor Drive', 'Electrify + Volt Absorb', 'Lunatic Time', 'Green Card', 'Time Stasis', 'Suwise Glasses', 'Pressure Orb', 'Training Glove', 'Wire Trap', 'Sketch', 'Soul Barrier',
+			'Hell Drag', 'Pacify', 'Kaleido Scope', 'WildBeastsLogic', 'Squirm', 'Rift Strike', 'Magic Cape', 'After Image','Perfect Freeze', 'Electrify + Lightning Rod', 'Electrify + Motor Drive', 'Electrify + Volt Absorb', 'Lunatic Time', 'Green Card', 'Time Stasis', 'Suwise Glasses', 'Pressure Orb', 'Training Glove', 'Wire Trap', 'Sketch', 'Soul Barrier',
 		],
 	},
 	
@@ -1013,7 +1013,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
+			'Hell Drag', 'Pacify', 'Magic Cape', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
 		],
 	},
 	{
@@ -1035,7 +1035,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
+			'Hell Drag', 'Pacify','Magic Cape', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
 		],
 	},
 	{
@@ -1057,7 +1057,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
+			'Hell Drag', 'Pacify', 'Magic Cape','Rift Strike', 'Perfect Freeze', 'Time Stasis',
 		],
 	},
 	{
@@ -1094,7 +1094,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
+			'Hell Drag', 'Pacify', 'Magic Cape','Rift Strike', 'Perfect Freeze', 'Time Stasis',
 		],
 	},
 	{
@@ -1118,7 +1118,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
+			'Hell Drag', 'Pacify', 'Magic Cape', 'Rift Strike', 'Perfect Freeze', 'Time Stasis',
 		],
 	},
 	{
@@ -1177,7 +1177,7 @@ export const Formats: FormatList = [
 			'Corrupt Orb', 'Border Wall', 'Ultra Cloak', 'Ultra Scarf', 'Pitch Sludge', 'Apex Orb', 'Antiplebshield', 'GODSORB', 'Sans Hoodie',
 			'Ginsio Berry', 'Uranus Orb', 'Ballet Outfit', 'Frost Orb', 'Nap Orb', 'Ethereal', 'Glass Armor', 'Fangclaw', 'Craggy Helmet', 'Discombubbles',
 			'Bootsofblindingspeed + Bestow', 'Bootsofblindingspeed + Trick', 'Bootsofblindingspeed + Switcheroo', 'Inverted Rune', 'Sheriff Hat',
-			'Hell Drag', 'Pacify', 'Rift Strike', 'Perfect Freeze', 'Time Stasis', 'Suwise Glasses', 'Pressure Orb', 'Training Glove', 'Wire Trap', 'Sketch', 'Soul Barrier',
+			'Hell Drag', 'Pacify', 'Magic Cape', 'Rift Strike', 'Perfect Freeze', 'Time Stasis', 'Suwise Glasses', 'Pressure Orb', 'Training Glove', 'Wire Trap', 'Sketch', 'Soul Barrier',
 		],
 	},
 

--- a/data/abilities.ts
+++ b/data/abilities.ts
@@ -11258,9 +11258,9 @@ export const Abilities: {[abilityid: string]: AbilityData} = {
 		},
 		onModifyTypePriority: -1,
 		onModifyType(move, source) {
-			if (move.hit === 2 && move.type === source.getTypes()[0]) 
+			if (move.hit === 1 && move.type === source.getTypes()[0]) 
 				 move.type = source.getTypes()[1]; 
-			else if (move.hit === 2 && move.type === source.getTypes()[1]) 
+			else if (move.hit === 1 && move.type === source.getTypes()[1]) 
 				move.type = source.getTypes()[0]; 
 		},
 

--- a/data/items.ts
+++ b/data/items.ts
@@ -728,6 +728,7 @@ export const Items: {[itemid: string]: ItemData} = {
 				source.addVolatile('gem');
 			}
 		},
+		onGem: 'Bug',
 		num: 558,
 		gen: 5,
 		isNonstandard: "Past",
@@ -1302,6 +1303,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 562,
+		onDrive: 'Dark',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -1510,6 +1512,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 561,
+		onDrive: 'Dragon',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -1740,6 +1743,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 550,
+		onDrive: 'Electric',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -1898,6 +1902,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 715,
 		gen: 6,
+		onDrive: 'Fairy',
 		isNonstandard: "Past",
 		rating: 2,
 	},
@@ -1938,6 +1943,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 553,
 		gen: 5,
+		onGem: 'Fighting',
 		isNonstandard: "Past",
 		rating: 2,
 	},
@@ -2009,6 +2015,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 548,
+		onGem: 'Fire',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -2148,6 +2155,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 556,
+		onGem: 'Flying',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 3,
@@ -2395,6 +2403,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 560,
+		onGem: 'Ghost',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -2465,6 +2474,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 551,
+		onGem: 'Grass',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -2605,6 +2615,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 555,
+		onGem: 'Ground',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -2845,6 +2856,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 552,
+		onGem: 'Ice',
 		gen: 5,
 		isNonstandard: "Past",
 		rating: 2,
@@ -4248,6 +4260,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 564,
+		onGem: 'Normal',
 		gen: 5,
 		rating: 2,
 	},
@@ -4614,6 +4627,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 554,
 		gen: 5,
+		onGem: 'Poison',
 		isNonstandard: "Past",
 		rating: 2,
 	},
@@ -4835,6 +4849,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 557,
 		gen: 5,
+		onGem: 'Psychic',
 		isNonstandard: "Past",
 		rating: 2,
 	},
@@ -5188,6 +5203,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 559,
 		gen: 5,
+		onGem: 'Rock',
 		isNonstandard: "Past",
 		rating: 2,
 	},
@@ -6002,6 +6018,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 563,
 		gen: 5,
+		onGem: 'Steel',
 		isNonstandard: "Past",
 		rating: 2,
 	},
@@ -7594,6 +7611,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 549,
 		gen: 5,
+		onGem: 'Water',
 		isNonstandard: "Past",
 		rating: 2,
 	},
@@ -9967,6 +9985,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 558,
 		gen: 5,
+		onGem: 'PLastic',
 		isNonstandard: "Future",
 		rating: 1,
 	},
@@ -9982,6 +10001,7 @@ export const Items: {[itemid: string]: ItemData} = {
 		},
 		num: 558,
 		gen: 5,
+		onGem: 'Glass',
 		isNonstandard: "Future",
 		rating: 1,
 	},
@@ -14600,6 +14620,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67097,
+		onGem: 'Wood',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14615,6 +14636,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67098,
+		onGem: 'Magma',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14625,11 +14647,12 @@ export const Items: {[itemid: string]: ItemData} = {
 		onSourceTryPrimaryHit(target, source, move) {
 			const pledges = ['firepledge', 'grasspledge', 'waterpledge'];
 			if (target === source || move.category === 'Status' || pledges.includes(move.id)) return;
-			if (move.type === 'Magma' && source.useItem()) {
+			if (move.type === 'Steam' && source.useItem()) {
 				source.addVolatile('gem');
 			}
 		},
 		num: 67099,
+		onGem: 'Steam',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14645,6 +14668,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67100,
+		onGem: 'Wind',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14660,6 +14684,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67101,
+		onGem: 'Paper',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14675,6 +14700,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67102,
+		onGem: 'Tech',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14690,6 +14716,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67103,
+		onGem: 'Magic',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14705,6 +14732,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67104,
+		onGem: 'Rubber',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14720,6 +14748,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67105,
+		onGem: 'Fear',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14735,6 +14764,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67106,
+		onGem: 'Light',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14750,6 +14780,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67107,
+		onGem: 'Cosmic',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14765,6 +14796,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67108,
+		onGem: 'Sound',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14780,6 +14812,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67109,
+		onGem: 'Food',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14795,6 +14828,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67110,
+		onGem: 'Zombie',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14810,6 +14844,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67111,
+		onGem: 'Nuclear',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14825,6 +14860,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67112,
+		onGem: 'Virus',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14840,6 +14876,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67113,
+		onGem: 'Cyber',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14855,6 +14892,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67114,
+		onGem: 'Fabric',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14870,6 +14908,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67115,
+		onGem: 'Chaos',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14885,6 +14924,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67116,
+		onGem: 'Divine',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14900,6 +14940,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67117,
+		onGem: 'Qmarks',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14915,6 +14956,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67118,
+		onGem: 'Time',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14930,6 +14972,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67119,
+		onGem: 'Paint',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14945,6 +14988,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67120,
+		onGem: 'Crystal',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14960,6 +15004,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67121,
+		onGem: 'Meme',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14975,6 +15020,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67122,
+		onGem: 'Blood',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -14990,6 +15036,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67123,
+		onGem: 'Greasy',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -15005,6 +15052,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67124,
+		onGem: 'Heart',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -15020,6 +15068,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67125,
+		onGem: 'Ogre',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -15035,6 +15084,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			}
 		},
 		num: 67126,
+		onGem: 'Shadow',
 		isNonstandard: "Future",
 		rating: 2,
 	},
@@ -17773,7 +17823,7 @@ export const Items: {[itemid: string]: ItemData} = {
 			basePower: 80,
 		},
 		onDamagingHit(damage, target, source, move) {
-			if (!move.damage && !move.damageCallback && target.getMoveHitData(move).typeMod < 0) {
+			if (!move.damage && !move.damageCallback && target.getMoveHitData(move).typeMod > 0) {
 				target.useItem();
 			}
 		},

--- a/data/mods/wack/abilities.ts
+++ b/data/mods/wack/abilities.ts
@@ -1030,7 +1030,7 @@ export const Abilities: {[k: string]: ModdedAbilityData} = {
 			if (move.selfdestruct) delete move.selfdestruct;
 		},
 		onAfterMove(source, target, move) {
-			if (['explosion', 'mindblown', 'mistyexplosion', 'selfdestruct'].includes(move.id)) {
+			if (['explosion', 'mindblown', 'mistyexplosion', 'selfdestruct', 'mutualdestruction', 'nuclearexplosion'].includes(move.id)) {
 				this.damage(source.baseMaxhp / 5, source, source);
 			}
 		},

--- a/data/mods/wack/formats-data.ts
+++ b/data/mods/wack/formats-data.ts
@@ -2301,7 +2301,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	weavile: {
 		inherit: true,
-		tier: "UU",
+		tier: "OU",
 		isNonstandard: null,
 	},
 	magnezone: {
@@ -15172,7 +15172,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	kaguyainbow: {
 		inherit: true,
-		tier: "UU",
+		tier: "OU",
 		isNonstandard: null,
 	},
 	mokanou: {
@@ -18092,7 +18092,7 @@ export const FormatsData: { [k: string]: ModdedSpeciesFormatsData } = {
 	},
 	mpyroar: {
 		inherit: true,
-		tier: "UU",
+		tier: "OU",
 		isNonstandard: null,
 	},
 	ayymask: {

--- a/data/mods/wack/random-sets.json
+++ b/data/mods/wack/random-sets.json
@@ -11272,7 +11272,7 @@
           "explosion",
           "transform",
           "frostbreath",
-          "shadowcaw"
+          "shadowclaw"
         ],
         "level": 79
       }

--- a/data/mods/wackclover/learnsets.ts
+++ b/data/mods/wackclover/learnsets.ts
@@ -16420,6 +16420,7 @@ shedleaves: ["8L1"],
 	},
 	polossus: {
 		learnset: {
+			tempest: ["8L1"],
 			filthbomb: ["8L1"],
 			cloudcrash: ["8L1"],
 			wastecloud: ["8L1"],
@@ -17130,6 +17131,7 @@ charisma: ["8L1"],
 	},
 	spaghefant: {
 		learnset: {
+			meatmash: ["8L1"],
 			spagettiwrap: ["8L1"],
 			matzoball: ["8L1"],
 			searingsauce: ["8L1"],
@@ -25292,6 +25294,7 @@ sonicpulse: ["8L1"],
 	},
 	fondupple: {
 		learnset: {
+			sprinkle: ["8L1"],
 			poundcake: ["8L1"],
 cakeslice: ["8L1"],
 cakewalk: ["8L1"],

--- a/data/mods/wackclover/moves.ts
+++ b/data/mods/wackclover/moves.ts
@@ -1092,6 +1092,10 @@ export const Moves: { [k: string]: ModdedMoveData } = {
 		inherit: true,
 		isNonstandard: "Past",
 	},
+	sprinkle: {
+		inherit: true,
+		isNonstandard: "Past",
+	},
 	stoneaxe: {
 		inherit: true,
 		isNonstandard: "Past",

--- a/data/mods/wackclover/pokedex.ts
+++ b/data/mods/wackclover/pokedex.ts
@@ -412,6 +412,10 @@ export const Pokedex: {[k: string]: ModdedSpeciesData} = {
 		inherit: true,
 		types: ["Crystal", "Poison"],
 	},
+	polossus: {
+		inherit: true,
+		types: ["Poison", "Wind"],
+	},
 	snugware: {
 		inherit: true,
 		types: ["Bug", "Cyber"],

--- a/data/moves.ts
+++ b/data/moves.ts
@@ -1101,6 +1101,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 				source.skipBeforeSwitchOutEventFlag = true;
 			},
 		},
+		
 		selfSwitch: 'copyvolatile',
 		secondary: null,
 		target: "self",
@@ -40112,7 +40113,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, mirror: 1, defrost: 1},
 		secondary: {
 			chance: 30,
-			status: 'psn',
+			status: 'brn',
 		},
 		target: "normal",
 		type: "Nuclear",
@@ -41392,7 +41393,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {contact: 1, protect: 1, mirror: 1},
 		critRatio: 2,
 		secondary: null,
-		target: "self",
+		target: "normal",
 		type: "Ice",
 		isNonstandard: "Future",
 	},
@@ -63715,7 +63716,15 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1},
-		secondary: null,
+		boosts: {
+			evasion: 4,
+		},
+		secondary: {
+			chance: 100,
+			onHit(target) {
+				target.addVolatile('throatchop');
+			},
+		},
 		target: "self",
 		type: "Sound",
 		isNonstandard: "Future",
@@ -64075,8 +64084,15 @@ export const Moves: {[moveid: string]: MoveData} = {
 					return false;
 				}
 			},
+			onFieldResidualOrder: 27,
+			onFieldResidualSubOrder: 1,
+			onFieldEnd() {
+				this.add('-fieldend', 'move: Padded Room');
+			},
+		
 
 		},
+		
 		secondary: null,
 		target: "scripted",
 		type: "Fabric",
@@ -64319,6 +64335,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
+		status: 'brn',
 		secondary: null,
 		target: "normal",
 		type: "Fire",
@@ -67845,6 +67862,51 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1, bite: 1},
+		noSketch: true,
+		volatileStatus: 'saintwarorder',
+		condition: {
+			duration: 5,
+			onStart(target) {
+				this.add('-start', target, 'Saint War Order');
+				this.add('-message', 'Now is the time to advance! Saint War Order: Rally Upon the Holy Banner and Roar!');
+				this.add('-message', 'Attack Strength, Speed and Crit Rate went up!');
+			},
+			onModifyDamage(damage, source, target, move) {
+				if (target.getMoveHitData(move).crit) {
+					this.debug('Saint War Order boost');
+					return this.chainModify(2.0);
+				}
+			},
+			onModifyCritRatio(critRatio) {
+				return critRatio + 2;
+			},
+		onModifySpe(spe, pokemon) {
+				return this.chainModify(2.0);
+			},
+			onResidualOrder: 18,
+			onEnd(target) {
+				this.add('-end', target, 'Saint War Order');
+			},
+		},
+		
+		onTryHit(target) {
+			if (target.getAbility().isPermanent || target.ability === 'moxie' || target.ability === 'truant') {
+				return false;
+			}
+		},
+		onHit(pokemon) {
+			const oldAbility = pokemon.setAbility('moxie');
+			if (oldAbility) {
+				this.add('-ability', pokemon, 'Moxie', '[from] move: Saint War Order');
+				return;
+			}
+			return oldAbility as false | null;
+		},
+		self: {
+			boosts: {
+				def: -1,
+			},
+		},
 		secondary: null,
 		target: "self",
 		type: "Divine",
@@ -69234,6 +69296,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, bite: 1},
+		onHit(pokemon) {
+			const success = !!this.heal(this.modify(pokemon.maxhp, 0.5));
+			return pokemon.cureStatus() || success;
+		},
 		secondary: null,
 		target: "allySide",
 		type: "Sound",
@@ -74628,6 +74694,11 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, mirror: 1},
+		onModifyType(move, pokemon) {
+			let type = pokemon.getTypes()[0];
+			if (type === "Bird") type = "???";
+			move.type = type;
+		},
 		secondary: null,
 		target: "normal",
 		type: "Normal",
@@ -80122,17 +80193,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondaries: [
-			{
-				chance: 100,
-				self: {
-					status: 'prz',
-				},
-			}, {
-				chance: 100,
-				status: 'prz',
-			},
-		],
+		secondary: {
+			chance: 100,
+			status: 'par',
+		},
+		onAfterHit(target, source) {
+			source.trySetStatus('par');
+		},
 		target: "normal",
 		type: "Normal",
 		isNonstandard: "Future",
@@ -80795,17 +80862,13 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
-		secondaries: [
-			{
-				chance: 100,
-				self: {
-					status: 'prz',
-				},
-			}, {
-				chance: 100,
-				status: 'prz',
-			},
-		],
+		secondary: {
+			chance: 100,
+			status: 'par',
+		},
+		onAfterHit(target, source) {
+			source.trySetStatus('par');
+		},
 		target: "normal",
 		type: "Fighting",
 		isNonstandard: "Future",
@@ -81611,6 +81674,31 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
+		self: {
+			onHit(source) {
+				for (const side of source.side.foeSidesWithConditions()) {
+					side.addSideCondition('chaoslabyrintho');
+				}
+			},
+		},
+		condition: {
+			duration: 6,
+			onSideStart(targetSide) {
+				this.add('-sidestart', targetSide, 'Chaos Labyrintho');
+			},
+			onResidualOrder: 5,
+			onResidualSubOrder: 1,
+			onResidual(target) {
+				if (target.activeTurns) {
+					this.boost({atk: -1, def: 1});
+				}
+			},
+			onSideResidualOrder: 26,
+			onSideResidualSubOrder: 11,
+			onSideEnd(targetSide) {
+				this.add('-sideend', targetSide, 'Chaos Labyrintho');
+			},
+		},
 		secondary: null,
 		target: "foeSide",
 		type: "Chaos",
@@ -82213,6 +82301,35 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 20,
 		priority: 0,
 		flags: {snatch: 1},
+		volatileStatus: 'applylipstick',
+		condition: {
+			
+			onStart(target) {
+				this.add('-start', target, 'Apply Lipstick');
+				this.add('-message', 'increased the power of its kissing moves!');
+				
+			},
+			onBasePowerPriority: 1,
+			onBasePower(basePower, attacker, defender, move) {
+				if (move.flags.kiss ) {
+					this.debug('applylipstick increase');
+					return this.chainModify([2.0]);
+				}
+			},
+			onDamagingHitOrder: 1,
+		onHit(target, source, move) {
+			if (move.flags.kiss){
+				 if (this.randomChance(3, 10)) {
+					target.addVolatile('attract');
+				}
+			}
+			},
+			
+		onResidualOrder: 18,
+			onEnd(target) {
+				this.add('-end', target, 'Apply Lipstick');
+			},
+		},
 		secondary: null,
 		target: "self",
 		type: "Heart",
@@ -83500,6 +83617,16 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {snatch: 1},
+		onHit(target, pokemon, move) {
+			if (pokemon.item) return;
+			const types = this.dex.types.all().map((type) => type.name);
+			const newType = this.sample(types);
+			const itemText = `${newType} Gem`;
+				const item = this.dex.items.get(itemText);
+				if (pokemon.setItem(item)) {
+					this.add('-item', pokemon, item, '[from] move: Gem Create');
+				}
+		},
 		secondary: null,
 		target: "self",
 		type: "Crystal",
@@ -85765,7 +85892,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 5,
 		priority: 0,
 		flags: {protect: 1, mirror: 1, bite: 1},
-		secondary: null,
+		secondary: {
+			chance: 35,
+			volatileStatus: 'confusion',
+		},
 		target: "normal",
 		type: "Psychic",
 		isNonstandard: "Future",
@@ -89439,6 +89569,18 @@ export const Moves: {[moveid: string]: MoveData} = {
 		pp: 10,
 		priority: 0,
 		flags: {protect: 1, reflectable: 1, mirror: 1},
+		onHit(target) {
+			let move: Move | ActiveMove | null = target.lastMove;
+			if (!move || move.isZ) return false;
+			if (move.isMax && move.baseMove) move = this.dex.moves.get(move.baseMove);
+
+			const ppDeducted = target.deductPP(move.id, 2);
+			if (!ppDeducted) return false;
+			this.add("-activate", target, 'move: Pilpil', move.name, ppDeducted);
+		},
+		boosts: {
+			spd: 2,
+		},
 		secondary: null,
 		target: "normal",
 		type: "Normal",
@@ -90432,7 +90574,10 @@ export const Moves: {[moveid: string]: MoveData} = {
 		flags: {protect: 1, mirror: 1},
 		onModifyType(move, pokemon) {
 			if (pokemon.ignoringItem()) return;
-			move.type = this.runEvent('Gem', pokemon, null, move, 'Normal');
+			const item = pokemon.getItem();
+			if (item.id && item.onGem && !item.zMove) {
+				move.type = item.onGem;
+			}
 		},
 		secondary: null,
 		target: "normal",
@@ -91801,6 +91946,7 @@ export const Moves: {[moveid: string]: MoveData} = {
 		priority: 0,
 		flags: {contact: 1, protect: 1, mirror: 1},
 		secondary: null,
+		multihit: [2, 5],
 		target: "adjacentAllyOrSelf",
 		type: "Dark",
 		isNonstandard: "Future",

--- a/sim/dex-items.ts
+++ b/sim/dex-items.ts
@@ -87,6 +87,11 @@ export class Item extends BasicEffect implements Readonly<BasicEffect> {
 	/** Is this item a Gem? */
 	readonly isGem: boolean;
 	/** Is this item a Pokeball? */
+	readonly onGem?: string;
+	/**
+	 * If this is a Gem: The type it turns stuff into.
+	 * undefined, if not a Gem.
+	 */
 	readonly isPokeball: boolean;
 	/** Rating from -1 Detrimental to +5 Essential; see `data/abilities.ts` for details. */
 	readonly rating: number;
@@ -122,6 +127,7 @@ export class Item extends BasicEffect implements Readonly<BasicEffect> {
 		this.isBerry = !!data.isBerry;
 		this.ignoreKlutz = !!data.ignoreKlutz;
 		this.onPlate = data.onPlate || undefined;
+		this.onGem = data.onGem || undefined;
 		this.isGem = !!data.isGem;
 		this.isPokeball = !!data.isPokeball;
 		this.rating = data.rating || 0;


### PR DESCRIPTION
Bans 'Kaleido Scope', 'WildBeastsLogic', 'Squirm', 'Rift Strike', 'Magic Cape' from Wack UU.  Also moves Kaguyaimbow, Weavile, and Mega Pyroar to OU.

Fixes various Wack moves

Polossus is now Poison/Wind in Wack Clover